### PR TITLE
Allow .notConsumable() to take an IItemStack

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipeBuilder.java
@@ -54,8 +54,10 @@ public class CTRecipeBuilder {
     }
 
     @ZenMethod
-    public CTRecipeBuilder notConsumable(IIngredient ingredient) {
-        this.backingBuilder.notConsumable(new CraftTweakerIngredientWrapper(ingredient));
+    public CTRecipeBuilder notConsumable(IIngredient... ingredients) {
+        this.backingBuilder.inputsIngredients(Arrays.stream(ingredients)
+                .map(s -> new CountableIngredient(new CraftTweakerIngredientWrapper(s), 0))
+                .collect(Collectors.toList()));
         return this;
     }
 


### PR DESCRIPTION
What: 
This changes the implementation of the CT method notConsumable() to accept an IItemStack.

How solved:
I used the same implementation of the method Input() and manually set the stack size of each item to 0.

Outcome:
This allows not Consumables to be condensed to one line instead of needing to call the method multiple times.

Possible compatibility issue:
None

