### PR TITLE
Add EBF Pyrometallurgy Recipes

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -440,7 +440,7 @@ public class Materials {
     public static SimpleDustMaterial PotassiumDichromate = new SimpleDustMaterial(18, "potassium_dichromate", 0xFF084E, DULL, of(new MaterialStack(Potassium, 2), new MaterialStack(Chrome, 2), new MaterialStack(Oxygen, 7)), GENERATE_SMALL_TINY);
     public static SimpleDustMaterial ChromiumTrioxide = new SimpleDustMaterial(19, "chromium_trioxide", 0xFFE4E1, DULL, of(new MaterialStack(Chrome, 1), new MaterialStack(Oxygen, 3)), GENERATE_SMALL_TINY);
     public static SimpleDustMaterial AntimonyTrioxide = new SimpleDustMaterial(20, "antimony_trioxide", 0xE6E6F0, DULL, of(new MaterialStack(Antimony, 2), new MaterialStack(Oxygen, 3)), GENERATE_SMALL_TINY);
-    public static SimpleDustMaterial Zincite = new SimpleDustMaterial(21, "zincite", 0xFFFFF5, DULL, of(new MaterialStack(Zinc, 1), new MaterialStack(Oxygen, 1)), 0); //todo this isn't getting registered
+    public static SimpleDustMaterial Zincite = new SimpleDustMaterial(21, "zincite", 0xFFFFF5, DULL, of(new MaterialStack(Zinc, 1), new MaterialStack(Oxygen, 1)), 0);
     public static SimpleDustMaterial CupricOxide = new SimpleDustMaterial(22, "cupric_oxide", 0x0F0F0F, DULL, of(new MaterialStack(Copper, 1), new MaterialStack(Oxygen, 1)), 0);
     public static SimpleDustMaterial CobaltOxide = new SimpleDustMaterial(23, "cobalt_oxide", 0x788000, DULL, of(new MaterialStack(Cobalt, 1), new MaterialStack(Oxygen, 1)), 0);
     public static SimpleDustMaterial ArsenicTrioxide = new SimpleDustMaterial(24, "arsenic_trioxide", 0xFFFFFF, ROUGH, of(new MaterialStack(Arsenic, 2), new MaterialStack(Oxygen, 3)), GENERATE_SMALL_TINY);

--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -439,6 +439,14 @@ public class Materials {
     public static SimpleDustMaterial Agar = new SimpleDustMaterial(17, "agar", 0x4F7942, ROUGH, of(), 0);
     public static SimpleDustMaterial PotassiumDichromate = new SimpleDustMaterial(18, "potassium_dichromate", 0xFF084E, DULL, of(new MaterialStack(Potassium, 2), new MaterialStack(Chrome, 2), new MaterialStack(Oxygen, 7)), GENERATE_SMALL_TINY);
     public static SimpleDustMaterial ChromiumTrioxide = new SimpleDustMaterial(19, "chromium_trioxide", 0xFFE4E1, DULL, of(new MaterialStack(Chrome, 1), new MaterialStack(Oxygen, 3)), GENERATE_SMALL_TINY);
+    public static SimpleDustMaterial AntimonyTrioxide = new SimpleDustMaterial(20, "antimony_trioxide", 0xE6E6F0, DULL, of(new MaterialStack(Antimony, 2), new MaterialStack(Oxygen, 3)), GENERATE_SMALL_TINY);
+    public static SimpleDustMaterial Zincite = new SimpleDustMaterial(21, "zincite", 0xFFFFF5, DULL, of(new MaterialStack(Zinc, 1), new MaterialStack(Oxygen, 1)), 0); //todo this isn't getting registered
+    public static SimpleDustMaterial CupricOxide = new SimpleDustMaterial(22, "cupric_oxide", 0x0F0F0F, DULL, of(new MaterialStack(Copper, 1), new MaterialStack(Oxygen, 1)), 0);
+    public static SimpleDustMaterial CobaltOxide = new SimpleDustMaterial(23, "cobalt_oxide", 0x788000, DULL, of(new MaterialStack(Cobalt, 1), new MaterialStack(Oxygen, 1)), 0);
+    public static SimpleDustMaterial ArsenicTrioxide = new SimpleDustMaterial(24, "arsenic_trioxide", 0xFFFFFF, ROUGH, of(new MaterialStack(Arsenic, 2), new MaterialStack(Oxygen, 3)), GENERATE_SMALL_TINY);
+    public static SimpleDustMaterial Massicot = new SimpleDustMaterial(25, "massicot", 0xFFDD55, DULL, of(new MaterialStack(Lead, 1), new MaterialStack(Oxygen, 1)), 0);
+    public static SimpleDustMaterial Ferrosilite = new SimpleDustMaterial(26, "ferrosilite", 0x97632A, DULL, of(new MaterialStack(Iron, 1), new MaterialStack(Silicon, 1), new MaterialStack(Oxygen, 3)), 0);
+
 
     /**
      * Organic chemistry

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -95,11 +95,9 @@ public class MaterialRecipeHandler {
 
                 boolean hasHotIngot = OrePrefix.ingotHot.doGenerateItem(metalMaterial);
                 ItemStack ingotStack = OreDictUnifier.get(hasHotIngot ? OrePrefix.ingotHot : OrePrefix.ingot, metalMaterial);
-                ItemStack nuggetStack = OreDictUnifier.get(OrePrefix.nugget, metalMaterial);
 
                 if (metalMaterial.blastFurnaceTemperature <= 0) {
                     ModHandler.addSmeltingRecipe(new UnificationEntry(dustPrefix, metalMaterial), ingotStack);
-                    ModHandler.addSmeltingRecipe(new UnificationEntry(OrePrefix.dustTiny, metalMaterial), nuggetStack);
                 } else {
                     int duration = Math.max(1, (int) (metalMaterial.getAverageMass() * metalMaterial.blastFurnaceTemperature / 50L));
                     ModHandler.removeFurnaceSmelting(new UnificationEntry(OrePrefix.ingot, metalMaterial));
@@ -113,18 +111,6 @@ public class MaterialRecipeHandler {
                         ingotSmeltingBuilder.inputs(new CountableIngredient(new IntCircuitIngredient(1), 0));
                     }
                     ingotSmeltingBuilder.buildAndRegister();
-
-                    if (!hasHotIngot) {
-                        BlastRecipeBuilder nuggetSmeltingBuilder = RecipeMaps.BLAST_RECIPES.recipeBuilder()
-                                .input(OrePrefix.dustTiny, metalMaterial)
-                                .outputs(nuggetStack)
-                                .blastFurnaceTemp(metalMaterial.blastFurnaceTemperature)
-                                .duration(Math.max(1, duration / 9)).EUt(120);
-                        if (circuitRequiringMaterials.contains(metalMaterial)) {
-                            nuggetSmeltingBuilder.inputs(IntCircuitIngredient.getIntegratedCircuit(1));
-                        }
-                        nuggetSmeltingBuilder.buildAndRegister();
-                    }
 
                     if (hasHotIngot) {
                         RecipeMaps.VACUUM_RECIPES.recipeBuilder()

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -565,34 +565,6 @@ public class MachineRecipeLoader {
         createSulfurDioxideRecipe(Pyrite, BandedIron, 2000);
         createSulfurDioxideRecipe(Pentlandite, Garnierite, 1000);
 
-        createCarbonDioxideRecipe(CupricOxide, Copper, 1000);
-        createCarbonDioxideRecipe(Garnierite, Nickel, 1000);
-        createCarbonDioxideRecipe(BandedIron, Iron, 1000);
-        createCarbonDioxideRecipe(Zincite, Zinc, 1000);
-        createCarbonDioxideRecipe(AntimonyTrioxide, Antimony, 3000);
-        createCarbonDioxideRecipe(Magnetite, Iron, 1000);
-        createCarbonDioxideRecipe(Malachite, Copper, 3000);
-        createCarbonDioxideRecipe(Cassiterite, Tin, 1000);
-        createCarbonDioxideRecipe(CassiteriteSand, Tin, 1000);
-        createCarbonDioxideRecipe(BrownLimonite, Iron, 1000);
-        createCarbonDioxideRecipe(Massicot, Lead, 1000);
-        createCarbonDioxideRecipe(YellowLimonite, Iron, 1000);
-        createCarbonDioxideRecipe(GraniticMineralSand, Iron, 1000);
-        createCarbonDioxideRecipe(BasalticMineralSand, Iron, 1000);
-        createCarbonDioxideRecipe(CobaltOxide, Cobalt, 1000);
-
-        createCalciteOreRecipe(Pyrite, Iron);
-        createCalciteOreRecipe(Magnetite, Iron);
-        createCalciteOreRecipe(YellowLimonite, Iron);
-        createCalciteOreRecipe(BrownLimonite, Iron);
-        createCalciteOreRecipe(Iron, Iron);
-
-        createQuicklimeOreRecipe(Pyrite, Iron);
-        createQuicklimeOreRecipe(Magnetite, Iron);
-        createQuicklimeOreRecipe(BrownLimonite, Iron);
-        createQuicklimeOreRecipe(GraniticMineralSand, Iron);
-        createQuicklimeOreRecipe(Iron, Iron);
-
         BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
                 .input(dust, Tetrahedrite)
                 .fluidInputs(Oxygen.getFluid(3000))
@@ -617,15 +589,14 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(1000))
                 .buildAndRegister();
 
-        //todo this causes problems
-//        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
-//                .input(dust, Chalcopyrite)
-//                .input(dust, SiliconDioxide)
-//                .fluidInputs(Oxygen.getFluid(3000))
-//                .output(dust, CupricOxide)
-//                .output(dust, Ferrosilite)
-//                .fluidOutputs(SulfurDioxide.getFluid(2000))
-//                .buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, Chalcopyrite)
+                .input(dust, SiliconDioxide)
+                .fluidInputs(Oxygen.getFluid(3000))
+                .output(dust, CupricOxide)
+                .output(dust, Ferrosilite)
+                .fluidOutputs(SulfurDioxide.getFluid(2000))
+                .buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder().duration(240).EUt(120).blastFurnaceTemp(1200)
                 .input(dust, SiliconDioxide)
@@ -645,35 +616,6 @@ public class MachineRecipeLoader {
                 .fluidOutputs(SulfurDioxide.getFluid(sulfurDioxideAmount))
                 .buildAndRegister();
     }
-
-    private static void createCarbonDioxideRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial, int carbonDioxideAmount) {
-        BLAST_RECIPES.recipeBuilder().duration(240).EUt(120).blastFurnaceTemp(1200)
-                .input(dust, inputMaterial, 2)
-                .input(dust, Carbon)
-                .output(ingot, outputMaterial, 3)
-                .output(dustTiny, Ash, 2)
-                .fluidOutputs(CarbonDioxide.getFluid(carbonDioxideAmount))
-                .buildAndRegister();
-    }
-
-    private static void createCalciteOreRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial) {
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).blastFurnaceTemp(1500)
-                .input(ore, inputMaterial)
-                .input(dust, Calcite)
-                .output(ingot, outputMaterial, 3)
-                .output(dustSmall, DarkAsh)
-                .buildAndRegister();
-    }
-
-    private static void createQuicklimeOreRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial) {
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).blastFurnaceTemp(1500)
-                .input(ore, inputMaterial)
-                .input(dustTiny, Quicklime, 3)
-                .output(ingot, outputMaterial, 2)
-                .output(dustSmall, DarkAsh)
-                .buildAndRegister();
-    }
-
 
     private static void registerDecompositionRecipes() {
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -9,16 +9,14 @@ import gregtech.api.recipes.builders.CokeOvenRecipeBuilder;
 import gregtech.api.recipes.builders.PBFRecipeBuilder;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.material.IMaterial;
 import gregtech.api.unification.material.MarkerMaterials;
-import gregtech.api.unification.material.MarkerMaterials.Color;
 import gregtech.api.unification.material.MarkerMaterials.Tier;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.type.IngotMaterial;
 import gregtech.api.unification.material.type.Material;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.MaterialStack;
-import gregtech.api.unification.stack.UnificationEntry;
-import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import gregtech.common.blocks.BlockConcrete.ConcreteVariant;
 import gregtech.common.blocks.BlockGranite.GraniteVariant;
@@ -40,16 +38,8 @@ import gregtech.loaders.recipe.chemistry.ChemistryRecipes;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.EnumDyeColor;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemFood;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.IStringSerializable;
-import net.minecraft.util.Tuple;
-import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
-
-import java.util.Collection;
-import java.util.List;
 
 import static gregtech.api.GTValues.L;
 import static gregtech.api.recipes.RecipeMaps.*;
@@ -550,23 +540,138 @@ public class MachineRecipeLoader {
         BLAST_RECIPES.recipeBuilder().duration((int) Math.max(VanadiumGallium.getAverageMass() / 40, 1) * VanadiumGallium.blastFurnaceTemperature).EUt(480).input(ingot, Vanadium, 3).input(ingot, Gallium).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.VanadiumGallium, 4), OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh, 2)).blastFurnaceTemp(VanadiumGallium.blastFurnaceTemperature).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration((int) Math.max(NiobiumTitanium.getAverageMass() / 80, 1) * NiobiumTitanium.blastFurnaceTemperature).EUt(480).input(ingot, Niobium).input(ingot, Titanium).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.NiobiumTitanium, 2), OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh)).blastFurnaceTemp(NiobiumTitanium.blastFurnaceTemperature).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration((int) Math.max(Nichrome.getAverageMass() / 32, 1) * Nichrome.blastFurnaceTemperature).EUt(480).input(ingot, Nickel, 4).input(ingot, Chrome).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.Nichrome, 5), OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh, 2)).blastFurnaceTemp(Nichrome.blastFurnaceTemperature).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Ruby).outputs(OreDictUnifier.get(nugget, Aluminium, 5), OreDictUnifier.get(dustTiny, DarkAsh, 4)).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Ruby).outputs(OreDictUnifier.get(nugget, Aluminium, 5), OreDictUnifier.get(dustTiny, DarkAsh, 4)).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, GreenSapphire).output(nugget, Aluminium, 5).output(dustTiny, DarkAsh, 4).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).outputs(OreDictUnifier.get(nugget, Aluminium, 5), OreDictUnifier.get(dustTiny, DarkAsh, 4)).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Sapphire).outputs(OreDictUnifier.get(nugget, Aluminium, 5), OreDictUnifier.get(dustTiny, DarkAsh, 4)).blastFurnaceTemp(1200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Sapphire).outputs(OreDictUnifier.get(nugget, Aluminium, 5), OreDictUnifier.get(dustTiny, DarkAsh, 4)).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Ruby).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Ruby).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, GreenSapphire).output(nugget, Aluminium, 3).output(dustTiny, DarkAsh).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(400).EUt(100).input(dust, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(320).EUt(100).input(gem, Sapphire).output(nugget, Aluminium, 3).blastFurnaceTemp(1200).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(800).EUt(500).input(dust, Ilmenite, 5).outputs(OreDictUnifier.get(ingot, WroughtIron), OreDictUnifier.get(dust, Rutile, 3)).blastFurnaceTemp(1700).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(800).EUt(480).input(dust, Magnesium, 2).fluidInputs(TitaniumTetrachloride.getFluid(1000)).outputs(OreDictUnifier.get(OrePrefix.ingotHot, Materials.Titanium), OreDictUnifier.get(OrePrefix.dust, Materials.MagnesiumChloride, 6)).blastFurnaceTemp(Materials.Titanium.blastFurnaceTemperature + 200).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(500).input(dust, Galena).fluidInputs(Oxygen.getFluid(2000)).outputs(OreDictUnifier.get(nugget, Silver, 4), OreDictUnifier.get(OrePrefix.nugget, Materials.Lead, 4)).blastFurnaceTemp(1500).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(400).EUt(500).input(dust, Magnetite).fluidInputs(Oxygen.getFluid(2000)).outputs(OreDictUnifier.get(nugget, WroughtIron, 4), OreDictUnifier.get(dustSmall, DarkAsh)).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).input(ingot, Iron).fluidInputs(Oxygen.getFluid(1000)).outputs(OreDictUnifier.get(ingot, Steel), OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh)).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(100).EUt(120).input(ingot, PigIron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustSmall, DarkAsh).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(100).EUt(120).input(ingot, WroughtIron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustSmall, DarkAsh).blastFurnaceTemp(1000).buildAndRegister();
-        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).input(dust, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).input(ingot, Iron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(100).EUt(120).input(ingot, PigIron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(100).EUt(120).input(ingot, WroughtIron).fluidInputs(Oxygen.getFluid(1000)).output(ingot, Steel).output(dustTiny, Ash).blastFurnaceTemp(1000).buildAndRegister();
+        BLAST_RECIPES.recipeBuilder().duration(200).EUt(120).input(dust, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).input(ingot, Copper).fluidInputs(Oxygen.getFluid(1000)).output(ingot, AnnealedCopper).blastFurnaceTemp(1200).notConsumable(new IntCircuitIngredient(1)).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(500).EUt(1920).input(ingot, Iridium, 3).input(ingot, Osmium).fluidInputs(Helium.getFluid(1000)).output(ingotHot, Osmiridium, 4).blastFurnaceTemp(2900).buildAndRegister();
         BLAST_RECIPES.recipeBuilder().duration(500).EUt(30720).input(ingot, Naquadah).input(ingot, Osmiridium).fluidInputs(Argon.getFluid(1000)).output(ingotHot, NaquadahAlloy, 2).blastFurnaceTemp(NaquadahAlloy.blastFurnaceTemperature).buildAndRegister();
+
+        registerBlastFurnaceMetallurgyRecipes();
+    }
+
+    private static void registerBlastFurnaceMetallurgyRecipes() {
+        createSulfurDioxideRecipe(Stibnite, AntimonyTrioxide, 1500);
+        createSulfurDioxideRecipe(Sphalerite, Zincite, 1000);
+        createSulfurDioxideRecipe(Pyrite, BandedIron, 2000);
+        createSulfurDioxideRecipe(Pentlandite, Garnierite, 1000);
+
+        createCarbonDioxideRecipe(CupricOxide, Copper, 1000);
+        createCarbonDioxideRecipe(Garnierite, Nickel, 1000);
+        createCarbonDioxideRecipe(BandedIron, Iron, 1000);
+        createCarbonDioxideRecipe(Zincite, Zinc, 1000);
+        createCarbonDioxideRecipe(AntimonyTrioxide, Antimony, 3000);
+        createCarbonDioxideRecipe(Magnetite, Iron, 1000);
+        createCarbonDioxideRecipe(Malachite, Copper, 3000);
+        createCarbonDioxideRecipe(Cassiterite, Tin, 1000);
+        createCarbonDioxideRecipe(CassiteriteSand, Tin, 1000);
+        createCarbonDioxideRecipe(BrownLimonite, Iron, 1000);
+        createCarbonDioxideRecipe(Massicot, Lead, 1000);
+        createCarbonDioxideRecipe(YellowLimonite, Iron, 1000);
+        createCarbonDioxideRecipe(GraniticMineralSand, Iron, 1000);
+        createCarbonDioxideRecipe(BasalticMineralSand, Iron, 1000);
+        createCarbonDioxideRecipe(CobaltOxide, Cobalt, 1000);
+
+        createCalciteOreRecipe(Pyrite, Iron);
+        createCalciteOreRecipe(Magnetite, Iron);
+        createCalciteOreRecipe(YellowLimonite, Iron);
+        createCalciteOreRecipe(BrownLimonite, Iron);
+        createCalciteOreRecipe(Iron, Iron);
+
+        createQuicklimeOreRecipe(Pyrite, Iron);
+        createQuicklimeOreRecipe(Magnetite, Iron);
+        createQuicklimeOreRecipe(BrownLimonite, Iron);
+        createQuicklimeOreRecipe(GraniticMineralSand, Iron);
+        createQuicklimeOreRecipe(Iron, Iron);
+
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, Tetrahedrite)
+                .fluidInputs(Oxygen.getFluid(3000))
+                .output(dust, CupricOxide)
+                .output(dustTiny, AntimonyTrioxide, 3)
+                .fluidOutputs(SulfurDioxide.getFluid(2000))
+                .buildAndRegister();
+
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, Cobaltite)
+                .fluidInputs(Oxygen.getFluid(3000))
+                .output(dust, CobaltOxide)
+                .output(dust, ArsenicTrioxide)
+                .fluidOutputs(SulfurDioxide.getFluid(1000))
+                .buildAndRegister();
+
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, Galena)
+                .fluidInputs(Oxygen.getFluid(3000))
+                .output(dust, Massicot)
+                .output(nugget, Silver, 6)
+                .fluidOutputs(SulfurDioxide.getFluid(1000))
+                .buildAndRegister();
+
+        //todo this causes problems
+//        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+//                .input(dust, Chalcopyrite)
+//                .input(dust, SiliconDioxide)
+//                .fluidInputs(Oxygen.getFluid(3000))
+//                .output(dust, CupricOxide)
+//                .output(dust, Ferrosilite)
+//                .fluidOutputs(SulfurDioxide.getFluid(2000))
+//                .buildAndRegister();
+
+        BLAST_RECIPES.recipeBuilder().duration(240).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, SiliconDioxide)
+                .input(dust, Carbon, 2)
+                .output(ingot, Silicon)
+                .output(dustTiny, Ash)
+                .fluidOutputs(CarbonMonoxide.getFluid(2000))
+                .buildAndRegister();
+    }
+
+    private static void createSulfurDioxideRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial, int sulfurDioxideAmount) {
+        BLAST_RECIPES.recipeBuilder().duration(120).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, inputMaterial)
+                .fluidInputs(Oxygen.getFluid(3000))
+                .output(dust, outputMaterial)
+                .output(dustTiny, Ash)
+                .fluidOutputs(SulfurDioxide.getFluid(sulfurDioxideAmount))
+                .buildAndRegister();
+    }
+
+    private static void createCarbonDioxideRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial, int carbonDioxideAmount) {
+        BLAST_RECIPES.recipeBuilder().duration(240).EUt(120).blastFurnaceTemp(1200)
+                .input(dust, inputMaterial, 2)
+                .input(dust, Carbon)
+                .output(ingot, outputMaterial, 3)
+                .output(dustTiny, Ash, 2)
+                .fluidOutputs(CarbonDioxide.getFluid(carbonDioxideAmount))
+                .buildAndRegister();
+    }
+
+    private static void createCalciteOreRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial) {
+        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).blastFurnaceTemp(1500)
+                .input(ore, inputMaterial)
+                .input(dust, Calcite)
+                .output(ingot, outputMaterial, 3)
+                .output(dustSmall, DarkAsh)
+                .buildAndRegister();
+    }
+
+    private static void createQuicklimeOreRecipe(IMaterial<?> inputMaterial, IMaterial<?> outputMaterial) {
+        BLAST_RECIPES.recipeBuilder().duration(500).EUt(120).blastFurnaceTemp(1500)
+                .input(ore, inputMaterial)
+                .input(dustTiny, Quicklime, 3)
+                .output(ingot, outputMaterial, 2)
+                .output(dustSmall, DarkAsh)
+                .buildAndRegister();
     }
 
 

--- a/src/main/java/gregtech/loaders/recipe/chemistry/ChemistryRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/ChemistryRecipes.java
@@ -48,11 +48,11 @@ public class ChemistryRecipes {
             .duration(400).EUt(30).buildAndRegister();
 
         BLAST_RECIPES.recipeBuilder()
-            .input(dust, FerriteMixture, 6)
-            .fluidInputs(Oxygen.getFluid(8000))
-            .output(ingot, NickelZincFerrite, 14)
+            .input(dust, FerriteMixture)
+            .fluidInputs(Oxygen.getFluid(2000))
+            .output(ingot, NickelZincFerrite)
             .blastFurnaceTemp(1500)
-            .duration(3200).EUt(120).buildAndRegister();
+            .duration(400).EUt(120).buildAndRegister();
 
         FERMENTING_RECIPES.recipeBuilder()
             .fluidInputs(Biomass.getFluid(100))


### PR DESCRIPTION
Recipes to transform specific dusts into others in the EBF have been added in this PR. These recipes are lossy, but should not cause positive loops. Additionally, this PR removes tiny dust to nugget EBF and regular furnace recipes.