### PR TITLE
Add Tinted Machine Guis

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
@@ -6,6 +6,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.Widget;
 import gregtech.api.net.PacketUIWidgetUpdate;
 import gregtech.api.util.RenderUtil;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.client.renderer.GlStateManager;
@@ -20,12 +21,15 @@ import net.minecraftforge.common.MinecraftForge;
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 
-import java.awt.Rectangle;
+import java.awt.*;
 import java.io.IOException;
 
 public class ModularUIGui extends GuiContainer implements IRenderContext {
 
     private final ModularUI modularUI;
+    private static float rColorForOverlay = ((ConfigHolder.U.GT5u.defaultPaintingColor >> 16) & 0xff) / 255.0F;
+    private static float gColorForOverlay = ((ConfigHolder.U.GT5u.defaultPaintingColor >> 8) & 0xff) / 255.0F;
+    private static float bColorForOverlay = (ConfigHolder.U.GT5u.defaultPaintingColor & 0xff) / 255.0F;
 
     public ModularUI getModularUI() {
         return modularUI;
@@ -204,10 +208,14 @@ public class ModularUIGui extends GuiContainer implements IRenderContext {
 
     @Override
     protected void drawGuiContainerBackgroundLayer(float partialTicks, int mouseX, int mouseY) {
+        GlStateManager.pushMatrix();
+        GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
+        GlStateManager.enableBlend();
+        GlStateManager.popMatrix();
         modularUI.backgroundPath.draw(guiLeft, guiTop, xSize, ySize);
         modularUI.guiWidgets.values().forEach(widget -> {
             GlStateManager.pushMatrix();
-            GlStateManager.color(1.0f, 1.0f, 1.0f);
+            GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
             GlStateManager.enableBlend();
             widget.drawInBackground(mouseX, mouseY, this);
             GlStateManager.popMatrix();

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -221,7 +221,7 @@ public class ConfigHolder {
             @Config.Comment("Whether or not to use polymers instead of rare metals for Carbon Fibers. REMOVES THE CHANCED OUTPUT! Default: false")
             public boolean polymerCarbonFiber = false;
 
-            @Config.Comment("The default color to overlay onto machines. \n16777215 (0xFFFFFF in decimal) is no coloring (default), and 13819135 (0xD2DCFF in decimal) is the classic blue from GT5.")
+            @Config.Comment("The default color to overlay onto machines. \n16777215 (0xFFFFFF in decimal) is no coloring (default), and 13819135 (0xD2DCFF in decimal) is the classic blue from GT5. This will also recolor machine GUIs.")
             @Config.Name("Default Machine Color")
             @Config.RequiresMcRestart
             public int defaultPaintingColor = 0xFFFFFF;


### PR DESCRIPTION
**What:**
This PR adds a tint to all ModularUI GUIs based off the config for machine colors in world.

**How solved:**
Changes were made in ModularUIGui to retrieve and utilize the config colors in order to apply a tint to specific portions of the gui. 

**Outcome:**
Adds GUI tints for machines, bringing back another missing GT5 feature.

**Additional info:**
A screenshot of a machine GUI tinted with the classic GT5 blue. Using pure white (the default), 0xFFFFFF, leaves the GUIs identical to the originals.
![image](https://user-images.githubusercontent.com/37029404/125323674-0f8e5c00-e30d-11eb-81bf-48a04ddef8c2.png)

**Possible compatibility issue:**
None are expected, though things might be very hard, if not impossible to see if a user uses 0x000000 for the color in the config.