### PR TITLE
Fixes the Right Click Action of Drums and Tanks

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -171,7 +171,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
 
     @Override
     public boolean onRightClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
-        return getWorld().isRemote || FluidUtil.interactWithFluidHandler(playerIn, hand, fluidTank);
+        return getWorld().isRemote || (FluidUtil.interactWithFluidHandler(playerIn, hand, fluidTank) && !playerIn.isSneaking());
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -603,7 +603,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
 
     @Override
     public boolean onRightClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
-        return getWorld().isRemote || (FluidUtil.interactWithFluidHandler(playerIn, hand, fluidInventory)&& !playerIn.isSneaking());
+        return getWorld().isRemote || (FluidUtil.interactWithFluidHandler(playerIn, hand, fluidInventory) && !playerIn.isSneaking());
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityTank.java
@@ -603,7 +603,7 @@ public class MetaTileEntityTank extends MetaTileEntity implements IFastRenderMet
 
     @Override
     public boolean onRightClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
-        return getWorld().isRemote || FluidUtil.interactWithFluidHandler(playerIn, hand, fluidInventory);
+        return getWorld().isRemote || (FluidUtil.interactWithFluidHandler(playerIn, hand, fluidInventory)&& !playerIn.isSneaking());
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
**What:**
When shift right clicking a tank with a tank in hand the second tank will now be placed.

**How solved:**
added a sneak check into onRightClick() in both classes

**Outcome:**
tanks/drums can now be placed while looking at a drum/tank

**Possible compatibility issue:**
none
