### PR TITLE
add decomposition recipe division

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Materials.java
+++ b/src/main/java/gregtech/api/unification/material/Materials.java
@@ -427,7 +427,7 @@ public class Materials {
     public static SimpleDustMaterial MagnesiumChloride = new SimpleDustMaterial(2, "magnesium_chloride", 0xD40D5C, DULL, of(new MaterialStack(Magnesium, 1), new MaterialStack(Chlorine, 2)), GENERATE_SMALL_TINY);
     public static SimpleDustMaterial RawRubber = new SimpleDustMaterial(3, "raw_rubber", 0xCCC789, DULL, of(new MaterialStack(Carbon, 5), new MaterialStack(Hydrogen, 8)), GENERATE_SMALL_TINY | DISABLE_DECOMPOSITION);
     public static SimpleDustMaterial SodiumSulfide = new SimpleDustMaterial(4, "sodium_sulfide", 0xFFE680, DULL, of(new MaterialStack(Sodium, 2), new MaterialStack(Sulfur, 1)), GENERATE_SMALL_TINY);
-    public static SimpleDustMaterial PhosphorusPentoxide = new SimpleDustMaterial(5, "phosphorus_pentoxide", 0xDCDC00, DULL, of(new MaterialStack(Phosphorus, 4), new MaterialStack(Oxygen, 10)), DISABLE_DECOMPOSITION | GENERATE_SMALL_TINY);
+    public static SimpleDustMaterial PhosphorusPentoxide = new SimpleDustMaterial(5, "phosphorus_pentoxide", 0xDCDC00, DULL, of(new MaterialStack(Phosphorus, 4), new MaterialStack(Oxygen, 10)), DECOMPOSITION_BY_CENTRIFUGING | GENERATE_SMALL_TINY);
     public static SimpleDustMaterial Quicklime = new SimpleDustMaterial(6, "quicklime", 0xF0F0F0, DULL, of(new MaterialStack(Calcium, 1), new MaterialStack(Oxygen, 1)), GENERATE_SMALL_TINY);
     public static SimpleDustMaterial SodiumBisulfate = new SimpleDustMaterial(7, "sodium_bisulfate", 0x004455, DULL, of(new MaterialStack(Sodium, 1), new MaterialStack(Hydrogen, 1), new MaterialStack(Sulfur, 1), new MaterialStack(Oxygen, 4)), DISABLE_DECOMPOSITION | GENERATE_SMALL_TINY);
     public static SimpleDustMaterial FerriteMixture = new SimpleDustMaterial(8, "ferrite_mixture", 0xB4B4B4, METALLIC, of(new MaterialStack(Nickel, 1), new MaterialStack(Zinc, 1), new MaterialStack(Iron, 4)), DECOMPOSITION_BY_CENTRIFUGING | GENERATE_SMALL_TINY);
@@ -533,7 +533,7 @@ public class Materials {
     public static DustMaterial GraniteBlack = new DustMaterial(308, "granite_black", 0x0A0A0A, ROUGH, 3, of(new MaterialStack(SiliconDioxide, 4), new MaterialStack(Biotite, 1)), NO_SMASHING | DECOMPOSITION_BY_CENTRIFUGING);
     public static DustMaterial GraniteRed = new DustMaterial(309, "granite_red", 0xFF0080, ROUGH, 3, of(new MaterialStack(Aluminium, 2), new MaterialStack(PotassiumFeldspar, 1), new MaterialStack(Oxygen, 3)), NO_SMASHING);
     public static DustMaterial Chrysotile = new DustMaterial(310, "chrysotile", 0x6E8C6E, ROUGH, 2, of(new MaterialStack(Asbestos, 1)), 0);
-    public static DustMaterial Realgar = new DustMaterial(311, "realgar", 0x8C6464, DULL, 2, of(new MaterialStack(Arsenic, 4), new MaterialStack(Sulfur, 4)), DISABLE_DECOMPOSITION);
+    public static DustMaterial Realgar = new DustMaterial(311, "realgar", 0x8C6464, DULL, 2, of(new MaterialStack(Arsenic, 4), new MaterialStack(Sulfur, 4)), DECOMPOSITION_BY_CENTRIFUGING);
     public static DustMaterial VanadiumMagnetite = new DustMaterial(312, "vanadium_magnetite", 0x23233C, METALLIC, 2, of(new MaterialStack(Magnetite, 1), new MaterialStack(Vanadium, 1)), GENERATE_ORE | DECOMPOSITION_BY_CENTRIFUGING);
     public static DustMaterial BasalticMineralSand = new DustMaterial(313, "basaltic_mineral_sand", 0x283228, SAND, 1, of(new MaterialStack(Magnetite, 1), new MaterialStack(Basalt, 1)), INDUCTION_SMELTING_LOW_OUTPUT);
     public static DustMaterial GraniticMineralSand = new DustMaterial(314, "granitic_mineral_sand", 0x283C3C, SAND, 1, of(new MaterialStack(Magnetite, 1), new MaterialStack(GraniteBlack, 1)), INDUCTION_SMELTING_LOW_OUTPUT);

--- a/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
@@ -66,7 +66,9 @@ public class DecompositionRecipeHandler {
             fluidOutputs.forEach(fluidStack -> materialAmounts.add(fluidStack.amount / 1000));
 
             int highestDivisor = 1;
-            for (int i = 2; i <= 64; i++) {
+
+            int smallestMaterialAmount = getSmallestMaterialAmount(materialAmounts);
+            for (int i = 2; i <= smallestMaterialAmount; i++) {
                 if (isEveryMaterialReducible(i, materialAmounts))
                     highestDivisor = i;
             }
@@ -133,6 +135,10 @@ public class DecompositionRecipeHandler {
         return true;
     }
 
+    private static int getSmallestMaterialAmount(List<Integer> materialAmounts) {
+        return materialAmounts.stream().min(Integer::compare).get();
+    }
+
     //todo think something better with this
     private static int getElectrolyzingVoltage(List<IMaterial<?>> components) {
         //tungsten-containing materials electrolyzing requires 1920
@@ -142,7 +148,7 @@ public class DecompositionRecipeHandler {
         if (components.size() <= 2) {
             return 30;
         }
-        return Math.min(2, components.size()) * 30;
+        return Math.max(2, components.size()) * 30;
     }
 
 }

--- a/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/DecompositionRecipeHandler.java
@@ -148,7 +148,7 @@ public class DecompositionRecipeHandler {
         if (components.size() <= 2) {
             return 30;
         }
-        return Math.max(2, components.size()) * 30;
+        return 2 * 30;
     }
 
 }

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -16,7 +16,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.Tuple;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import scala.tools.cmd.Meta;
 
 import java.util.Collection;
 import java.util.List;
@@ -181,21 +180,9 @@ public class SeparationRecipes {
                 .output(dustSmall, Gold, 2)
                 .buildAndRegister();
 
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(424).EUt(10)
-                .input(dust, Realgar, 2)
-                .output(dust, Arsenic)
-                .output(dust, Sulfur)
-                .buildAndRegister();
-
         CENTRIFUGE_RECIPES.recipeBuilder().duration(36).EUt(30)
                 .input(dust, Coal)
                 .output(dust, Carbon, 2)
-                .buildAndRegister();
-
-        CENTRIFUGE_RECIPES.recipeBuilder().duration(140).EUt(30)
-                .input(dust, PhosphorusPentoxide, 7)
-                .output(dust, Phosphorus, 2)
-                .fluidOutputs(Oxygen.getFluid(5000))
                 .buildAndRegister();
 
         CENTRIFUGE_RECIPES.recipeBuilder().duration(800).EUt(320)

--- a/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/SeparationRecipes.java
@@ -340,7 +340,7 @@ public class SeparationRecipes {
                 .output(dust, Aluminium, 16)
                 .fluidOutputs(Hydrogen.getFluid(10000))
                 .fluidOutputs(Oxygen.getFluid(11000))
-                .duration(2496).EUt(60).buildAndRegister();
+                .duration(624).EUt(60).buildAndRegister();
 
         ELECTROLYZER_RECIPES.recipeBuilder()
                 .fluidInputs(Water.getFluid(1000))

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -1374,6 +1374,7 @@ material.arsenic_trioxide=Arsenic Trioxide
 material.cupric_oxide=Cupric Oxide
 material.ferrosilite=Ferrosilite
 material.magnesia=Magnesia
+material.metal_mixture=Metal Mixture
 
 material.oil_heavy=Heavy Oil
 material.oil_medium=Raw Oil


### PR DESCRIPTION
This PR adds division for decomposition recipes. There are very few divisible recipes in GTCE, but Realgar and Phosphorus Pentoxide are good ones to check. The duration is divided accordingly. Fluid input decomposition recipes are not reduced, as they all go off of 1000mB input amounts.