### PR TITLE
Fix Tinting Issues with GUIs

### DIFF
--- a/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
+++ b/src/main/java/gregtech/api/gui/impl/ModularUIGui.java
@@ -27,9 +27,9 @@ import java.io.IOException;
 public class ModularUIGui extends GuiContainer implements IRenderContext {
 
     private final ModularUI modularUI;
-    private static float rColorForOverlay = ((ConfigHolder.U.GT5u.defaultPaintingColor >> 16) & 0xff) / 255.0F;
-    private static float gColorForOverlay = ((ConfigHolder.U.GT5u.defaultPaintingColor >> 8) & 0xff) / 255.0F;
-    private static float bColorForOverlay = (ConfigHolder.U.GT5u.defaultPaintingColor & 0xff) / 255.0F;
+    public static float rColorForOverlay = ((ConfigHolder.U.GT5u.defaultPaintingColor >> 16) & 0xff) / 255.0F;
+    public static float gColorForOverlay = ((ConfigHolder.U.GT5u.defaultPaintingColor >> 8) & 0xff) / 255.0F;
+    public static float bColorForOverlay = (ConfigHolder.U.GT5u.defaultPaintingColor & 0xff) / 255.0F;
 
     public ModularUI getModularUI() {
         return modularUI;

--- a/src/main/java/gregtech/api/gui/widgets/ClickButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/ClickButtonWidget.java
@@ -16,6 +16,8 @@ import org.lwjgl.input.Mouse;
 
 import java.util.function.Consumer;
 
+import static gregtech.api.gui.impl.ModularUIGui.*;
+
 public class ClickButtonWidget extends Widget {
 
     protected TextureArea buttonTexture = GuiTextures.VANILLA_BUTTON.getSubArea(0.0, 0.0, 1.0, 0.5);
@@ -54,7 +56,7 @@ public class ClickButtonWidget extends Widget {
         fontRenderer.drawString(text,
             position.x + size.width / 2 - fontRenderer.getStringWidth(text) / 2,
             position.y + size.height / 2 - fontRenderer.FONT_HEIGHT / 2, textColor);
-        GlStateManager.color(1.0f, 1.0f, 1.0f);
+        GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
     }
 
     @Override

--- a/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/CycleButtonWidget.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.*;
 
+import static gregtech.api.gui.impl.ModularUIGui.*;
+
 public class CycleButtonWidget extends Widget {
 
     protected TextureArea buttonTexture = GuiTextures.VANILLA_BUTTON.getSubArea(0.0, 0.0, 1.0, 0.5);
@@ -89,7 +91,7 @@ public class CycleButtonWidget extends Widget {
         fontRenderer.drawString(text,
             pos.x + size.width / 2 - fontRenderer.getStringWidth(text) / 2,
             pos.y + size.height / 2 - fontRenderer.FONT_HEIGHT / 2, textColor);
-        GlStateManager.color(1.0f, 1.0f, 1.0f);
+        GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
     }
 
     @Override

--- a/src/main/java/gregtech/api/gui/widgets/LabelWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/LabelWidget.java
@@ -4,12 +4,15 @@ import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.util.Position;
 import gregtech.api.util.Size;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.resources.I18n;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+
+import static gregtech.api.gui.impl.ModularUIGui.*;
 
 public class LabelWidget extends Widget {
 
@@ -67,7 +70,7 @@ public class LabelWidget extends Widget {
             fontRenderer.drawString(resultText,
                 pos.x - fontRenderer.getStringWidth(resultText) / 2, pos.y, color);
         }
-        GlStateManager.color(1.0f, 1.0f, 1.0f);
+        GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
     }
 
 }

--- a/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/PhantomFluidWidget.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static gregtech.api.gui.impl.ModularUIGui.*;
+
 public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhostIngredientTarget {
 
     protected TextureArea backgroundTexture = GuiTextures.FLUID_SLOT;
@@ -169,7 +171,7 @@ public class PhantomFluidWidget extends Widget implements IIngredientSlot, IGhos
             GlStateManager.disableBlend();
             RenderUtil.drawFluidForGui(lastFluidStack, lastFluidStack.amount, pos.x + 1, pos.y + 1, size.width - 1, size.height - 1);
             GlStateManager.enableBlend();
-            GlStateManager.color(1.0f, 1.0f, 1.0f);
+            GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
         }
     }
 

--- a/src/main/java/gregtech/api/gui/widgets/SimpleTextWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SimpleTextWidget.java
@@ -12,6 +12,8 @@ import net.minecraft.network.PacketBuffer;
 
 import java.util.function.Supplier;
 
+import static gregtech.api.gui.impl.ModularUIGui.*;
+
 /**
  * Simple one-line text widget with text synced and displayed
  * as the raw string from the server
@@ -51,7 +53,7 @@ public class SimpleTextWidget extends Widget {
         fontRenderer.drawString(text,
             position.x - fontRenderer.getStringWidth(text) / 2,
             position.y - fontRenderer.FONT_HEIGHT / 2, color);
-        GlStateManager.color(1.0f, 1.0f, 1.0f);
+        GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
     }
 
     @Override

--- a/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/SliderWidget.java
@@ -19,6 +19,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.function.BiFunction;
 
+import static gregtech.api.gui.impl.ModularUIGui.*;
+
 public class SliderWidget extends Widget {
 
     public static final BiFunction<String, Float, String> DEFAULT_TEXT_SUPPLIER = (name, value) -> I18n.format(name, value.intValue());
@@ -103,7 +105,7 @@ public class SliderWidget extends Widget {
         fontRenderer.drawString(displayString,
             pos.x + size.width / 2 - fontRenderer.getStringWidth(displayString) / 2,
             pos.y + size.height / 2 - fontRenderer.FONT_HEIGHT / 2, textColor);
-        GlStateManager.color(1.0f, 1.0f, 1.0f);
+        GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
     }
 
     @Override

--- a/src/main/java/gregtech/api/gui/widgets/TankWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/TankWidget.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static gregtech.api.gui.impl.ModularUIGui.*;
+
 public class TankWidget extends Widget implements IIngredientSlot {
 
     public final IFluidTank fluidTank;
@@ -129,7 +131,7 @@ public class TankWidget extends Widget implements IIngredientSlot {
                 GlStateManager.popMatrix();
             }
             GlStateManager.enableBlend();
-            GlStateManager.color(1.0f, 1.0f, 1.0f);
+            GlStateManager.color(rColorForOverlay, gColorForOverlay, bColorForOverlay, 1.0F);
         }
         if (overlayTexture != null) {
             overlayTexture.draw(pos.x, pos.y, size.width, size.height);


### PR DESCRIPTION
**What:**
Previously, tinting with certain AbstractWidgetGroups was failing, causing portions of the GUI to be untinted.

**How solved:**
To fix this, I found that certain widgets were actually resetting the coloration of GlStateManager to white, which prevented the rest of the widgets in an AbstractWidgetGroup to not get tinted. I changed the helper variables in ModularUIGUI to public, so that I could access those colors anywhere, and I then modified these lines to fix the issue.

**Outcome:**
Adds tinting back to GUIs, and fixes some widgets which were not tinted.
![unknown](https://user-images.githubusercontent.com/80226372/126053844-0fa96a3e-21fd-4ab2-a07f-c57b23502088.png)
