### PR TITLE
Make Dynamo hatches sided

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityEnergyHatch.java
@@ -33,6 +33,7 @@ public class MetaTileEntityEnergyHatch extends MetaTileEntityMultiblockPart impl
         this.isExportHatch = isExportHatch;
         if (isExportHatch) {
             this.energyContainer = EnergyContainerHandler.emitterContainer(this, GTValues.V[tier] * 128L, GTValues.V[tier], 4);
+            ((EnergyContainerHandler) this.energyContainer).setSideOutputCondition(s -> s == getFrontFacing());
         } else {
             this.energyContainer = EnergyContainerHandler.receiverContainer(this, GTValues.V[tier] * 16L, GTValues.V[tier], 2);
         }


### PR DESCRIPTION
**What:**
forces Dynamo hatches to only export energy on front face

**How solved:**
implemented getsetSideOutputCondition() for Dynamo hatches 

**Outcome:**
Dynamo hatches only export energy on front face

**Possible compatibility issue:**
none
