### PR TITLE
Add tank/drum clearing recipes

### DIFF
--- a/src/main/java/gregtech/common/ClientProxy.java
+++ b/src/main/java/gregtech/common/ClientProxy.java
@@ -173,7 +173,23 @@ public class ClientProxy extends CommonProxy {
     }
     private static final String[] clearRecipes = new String[]{
             "quantum_tank",
-            "quantum_chest"
+            "quantum_chest",
+            "super_chest",
+            "super_tank",
+            "drum.wood",
+            "drum.bronze",
+            "drum.steel",
+            "drum.aluminium",
+            "drum.stainless_steel",
+            "drum.titanium",
+            "drum.tungstensteel",
+            "wooden_tank",
+            "bronze_tank",
+            "aluminium_tank",
+            "stainless_steel_tan",
+            "titanium_tank",
+            "tungstensteel_tank"
+
     };
 
     @SubscribeEvent

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -998,6 +998,23 @@ public class MachineRecipeLoader {
             if (tank != null) {
                 ModHandler.addShapelessRecipe("quantum_tank_nbt_" + tank.getTier() + tank.metaTileEntityId, tank.getStackForm(), tank.getStackForm());
             }
-    }
+        
+        //Drums
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.WOODEN_DRUM.metaTileEntityId, MetaTileEntities.WOODEN_DRUM.getStackForm(), MetaTileEntities.WOODEN_DRUM.getStackForm());
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.BRONZE_DRUM.metaTileEntityId, MetaTileEntities.BRONZE_DRUM.getStackForm(), MetaTileEntities.BRONZE_DRUM.getStackForm());
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.STEEL_DRUM.metaTileEntityId, MetaTileEntities.STEEL_DRUM.getStackForm(), MetaTileEntities.STEEL_DRUM.getStackForm());
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.ALUMINIUM_DRUM.metaTileEntityId, MetaTileEntities.ALUMINIUM_DRUM.getStackForm(), MetaTileEntities.ALUMINIUM_DRUM.getStackForm());
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.STAINLESS_STEEL_DRUM.metaTileEntityId, MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm(), MetaTileEntities.STAINLESS_STEEL_DRUM.getStackForm());
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.TITANIUM_DRUM.metaTileEntityId, MetaTileEntities.TITANIUM_DRUM.getStackForm(), MetaTileEntities.TITANIUM_DRUM.getStackForm());
+        ModHandler.addShapelessRecipe("drum_nbt_"  + MetaTileEntities.TUNGSTENSTEEL_DRUM.metaTileEntityId, MetaTileEntities.TUNGSTENSTEEL_DRUM.getStackForm(), MetaTileEntities.TUNGSTENSTEEL_DRUM.getStackForm());
+        //Tanks
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.WOODEN_TANK.metaTileEntityId, MetaTileEntities.WOODEN_TANK.getStackForm(), MetaTileEntities.WOODEN_TANK.getStackForm());
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.BRONZE_TANK.metaTileEntityId, MetaTileEntities.BRONZE_TANK.getStackForm(), MetaTileEntities.BRONZE_TANK.getStackForm());
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.STEEL_TANK.metaTileEntityId, MetaTileEntities.STEEL_TANK.getStackForm(), MetaTileEntities.STEEL_TANK.getStackForm());
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.ALUMINIUM_TANK.metaTileEntityId, MetaTileEntities.ALUMINIUM_TANK.getStackForm(), MetaTileEntities.ALUMINIUM_TANK.getStackForm());
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.STAINLESS_STEEL_TANK.metaTileEntityId, MetaTileEntities.STAINLESS_STEEL_TANK.getStackForm(), MetaTileEntities.STAINLESS_STEEL_TANK.getStackForm());
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.TITANIUM_TANK.metaTileEntityId, MetaTileEntities.TITANIUM_TANK.getStackForm(), MetaTileEntities.TITANIUM_TANK.getStackForm());
+        ModHandler.addShapelessRecipe("tank_nbt_"  + MetaTileEntities.TUNGSTENSTEEL_TANK.metaTileEntityId, MetaTileEntities.TUNGSTENSTEEL_TANK.getStackForm(), MetaTileEntities.TUNGSTENSTEEL_TANK.getStackForm());
 
+    }
 }


### PR DESCRIPTION
**What:**
Adds recipes that allow the nbt to cleared from tanks/drums in registerNBTRemoval()


**Additional info:**
I added the clearing tooltip to  tanks, drums, and super tanks/drums. 


**Possible compatibility issue:**
None
