### PR TITLE
Fixed Material Casting and Added RecipeMap Bracket Handler

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -1,5 +1,6 @@
 package gregtech.api.recipes;
 
+import com.google.common.collect.ImmutableList;
 import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.liquid.ILiquidStack;
@@ -45,7 +46,6 @@ import java.util.stream.Collectors;
 @ZenRegister
 public class RecipeMap<R extends RecipeBuilder<R>> {
 
-    private static final List<RecipeMap<?>> RECIPE_MAPS = new ArrayList<>();
     private static final Map<String, RecipeMap<?>> RECIPE_MAP_REGISTRY = new HashMap<>();
     @ZenProperty
     public static IChanceFunction chanceFunction = (chance, boostPerTier, tier) -> chance + (boostPerTier * tier);
@@ -89,16 +89,15 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         this.isHidden = isHidden;
         defaultRecipe.setRecipeMap(this);
         this.recipeBuilderSample = defaultRecipe;
-        RECIPE_MAPS.add(this);
         RECIPE_MAP_REGISTRY.put(unlocalizedName, this);
     }
     @ZenMethod
     public static List<RecipeMap<?>> getRecipeMaps() {
-        return Collections.unmodifiableList(RECIPE_MAPS);
+        return ImmutableList.copyOf(RECIPE_MAP_REGISTRY.values());
     }
 
     public static void sortMaps() {
-        for (RecipeMap<?> rmap : RECIPE_MAPS) {
+        for (RecipeMap<?> rmap : RECIPE_MAP_REGISTRY.values()) {
             rmap.recipeList.sort(Comparator.comparingInt(Recipe::getDuration)
                     .thenComparingInt(Recipe::getEUt));
         }

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 public class RecipeMap<R extends RecipeBuilder<R>> {
 
     private static final List<RecipeMap<?>> RECIPE_MAPS = new ArrayList<>();
+    private static final Map<String, RecipeMap<?>> RECIPE_MAP_REGISTRY = new HashMap<>();
     @ZenProperty
     public static IChanceFunction chanceFunction = (chance, boostPerTier, tier) -> chance + (boostPerTier * tier);
 
@@ -89,6 +90,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         defaultRecipe.setRecipeMap(this);
         this.recipeBuilderSample = defaultRecipe;
         RECIPE_MAPS.add(this);
+        RECIPE_MAP_REGISTRY.put(unlocalizedName, this);
     }
     @ZenMethod
     public static List<RecipeMap<?>> getRecipeMaps() {
@@ -104,9 +106,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
 
     @ZenMethod
     public static RecipeMap<?> getByName(String unlocalizedName) {
-        return RECIPE_MAPS.stream()
-            .filter(map -> map.unlocalizedName.equals(unlocalizedName))
-            .findFirst().orElse(null);
+        return RECIPE_MAP_REGISTRY.get(unlocalizedName);
     }
 
     public static IChanceFunction getChanceFunction() {

--- a/src/main/java/gregtech/api/recipes/crafttweaker/RecipeMapBracketHandler.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/RecipeMapBracketHandler.java
@@ -1,0 +1,42 @@
+package gregtech.api.recipes.crafttweaker;
+
+import crafttweaker.CraftTweakerAPI;
+import crafttweaker.annotations.BracketHandler;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.zenscript.IBracketHandler;
+import gregtech.api.recipes.RecipeMap;
+import stanhebben.zenscript.compiler.IEnvironmentGlobal;
+import stanhebben.zenscript.expression.ExpressionCallStatic;
+import stanhebben.zenscript.expression.ExpressionString;
+import stanhebben.zenscript.parser.Token;
+import stanhebben.zenscript.symbols.IZenSymbol;
+import stanhebben.zenscript.type.natives.IJavaMethod;
+
+import java.util.List;
+
+@BracketHandler
+@ZenRegister
+public class RecipeMapBracketHandler implements IBracketHandler {
+    private final IJavaMethod method;
+
+    public RecipeMapBracketHandler() {
+        this.method = CraftTweakerAPI.getJavaMethod(RecipeMapBracketHandler.class, "getRecipeMap", String.class);
+    }
+
+    public static RecipeMap<?> getRecipeMap(String name) {
+        return RecipeMap.getByName(name);
+    }
+
+    @Override
+    public IZenSymbol resolve(IEnvironmentGlobal environment, List<Token> tokens) {
+        if ((tokens.size() < 3)) return null;
+        if (!tokens.get(0).getValue().equalsIgnoreCase("recipemap")) return null;
+        if (!tokens.get(1).getValue().equals(":")) return null;
+        StringBuilder nameBuilder = new StringBuilder();
+        for (int i = 2; i < tokens.size(); i++) {
+            nameBuilder.append(tokens.get(i).getValue());
+        }
+        return position -> new ExpressionCallStatic(position, environment, method,
+                new ExpressionString(position, nameBuilder.toString()));
+    }
+}

--- a/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialCasting.java
+++ b/src/main/java/gregtech/api/unification/crafttweaker/CTMaterialCasting.java
@@ -2,46 +2,54 @@ package gregtech.api.unification.crafttweaker;
 
 import crafttweaker.annotations.ZenRegister;
 import gregtech.api.unification.material.type.*;
+import stanhebben.zenscript.annotations.ZenCaster;
 import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenExpansion;
 import stanhebben.zenscript.annotations.ZenMethod;
 
 import javax.annotation.Nullable;
 
-@ZenClass("mods.gregtech.material.MaterialCasting")
+@ZenExpansion("mods.gregtech.material.Material")
 @ZenRegister
 public class CTMaterialCasting {
 
     @ZenMethod
+    @ZenCaster
     @Nullable
     public static FluidMaterial toFluid(Material material) {
         return cast(material, FluidMaterial.class);
     }
 
     @ZenMethod
+    @ZenCaster
     @Nullable
     public static DustMaterial toDust(Material material) {
         return cast(material, DustMaterial.class);
     }
 
     @ZenMethod
+    @ZenCaster
     @Nullable
     public static SolidMaterial toSolid(Material material) {
         return cast(material, SolidMaterial.class);
     }
 
     @ZenMethod
+    @ZenCaster
     @Nullable
     public static GemMaterial toGem(Material material) {
         return cast(material, GemMaterial.class);
     }
 
     @ZenMethod
+    @ZenCaster
     @Nullable
     public static IngotMaterial toIngot(Material material) {
         return cast(material, IngotMaterial.class);
     }
 
     @ZenMethod
+    @ZenCaster
     @Nullable
     public static RoughSolidMaterial toRoughSolid(Material material) {
         return cast(material, RoughSolidMaterial.class);


### PR DESCRIPTION
**What:**
+ Material Casting I.E. `<material:iron> as IngotMaterial`  
+ RecipeMap bracket handler and fixed RecipeMap findByName method.

**Possible compatibility issue:**
Changed the import `mods.gregtech.material.MaterialRegistry`, to a ZenExpansion of the import `mods.gregtech.material.Material`. So people will have to change past scripts a little if they used this class.