### PR TITLE
Add Multiblock cached value invalidation on structure deform

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -25,6 +25,13 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         super.update();
     }
 
+    /**
+     * Used to reset cached values in the Recipe Logic on structure deform
+     */
+    public void invalidate() {
+
+    }
+
     public IEnergyContainer getEnergyContainer() {
         RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
         return controller.getEnergyContainer();

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -84,6 +84,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     public void invalidateStructure() {
         super.invalidateStructure();
         resetTileAbilities();
+        this.recipeMapWorkable.invalidate();
     }
 
     @Override


### PR DESCRIPTION
**What:**
Adds a method so that recipe logic can invalidate cached variables on structure deform.

This is not done for the Steam logic and controller, as they are a target of a future refactor, which is when this should be added.

**How solved:**
Adds a new invalidate method

**Outcome:**
Adds a method so that recipe logic can invalidate cached variables on structure deform.
Closes #50

