### PR TITLE
Adjust assembler GUI, add Machine title offset

### DIFF
--- a/src/main/java/gregtech/api/gui/ModularUI.java
+++ b/src/main/java/gregtech/api/gui/ModularUI.java
@@ -93,6 +93,10 @@ public final class ModularUI implements ISizeProvider {
         return new Builder(GuiTextures.BACKGROUND, 176, 166);
     }
 
+    public static Builder defaultBuilder(int yOffset) {
+        return new Builder(GuiTextures.BACKGROUND, 176, 166 + yOffset);
+    }
+
     public static Builder borderedBuilder() {
         return new Builder(GuiTextures.BORDERED_BACKGROUND, 195, 136);
     }
@@ -175,7 +179,7 @@ public final class ModularUI implements ISizeProvider {
         }
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer) {
-            bindPlayerInventory(inventoryPlayer, GuiTextures.SLOT);
+            bindPlayerInventory(inventoryPlayer, GuiTextures.SLOT, 0);
             return this;
         }
 
@@ -184,8 +188,8 @@ public final class ModularUI implements ISizeProvider {
             return this;
         }
 
-        public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation) {
-            return bindPlayerInventory(inventoryPlayer, imageLocation, 7, 84);
+        public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int yOffset) {
+            return bindPlayerInventory(inventoryPlayer, imageLocation, 7, 84 + yOffset);
         }
 
         public Builder bindPlayerInventory(InventoryPlayer inventoryPlayer, TextureArea imageLocation, int x, int y) {

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -56,6 +56,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
 
     private static int inputTankCapacity = ConfigHolder.U.GT5u.useCustomMachineTankSizes ? ConfigHolder.U.GT5u.customMachineTankSizes[0] : 64000;
     private static int outputTankCapacity = ConfigHolder.U.GT5u.useCustomMachineTankSizes ? ConfigHolder.U.GT5u.customMachineTankSizes[1] : 64000;
+    private static final int FONT_HEIGHT = 9; // Minecraft's FontRenderer FONT_HEIGHT value
 
     public SimpleMachineMetaTileEntity(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap, OrientedOverlayRenderer renderer, int tier) {
         this(metaTileEntityId, recipeMap, renderer, tier, true);
@@ -316,30 +317,36 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     }
 
     protected ModularUI.Builder createGuiTemplate(EntityPlayer player) {
-        ModularUI.Builder builder = workable.recipeMap.createUITemplate(workable::getProgressPercent, importItems, exportItems, importFluids, exportFluids)
+        RecipeMap<?> workableRecipeMap = workable.recipeMap;
+        int yOffset = 0;
+        if (workableRecipeMap.getMaxInputs() > 6 || workableRecipeMap.getMaxFluidInputs() > 6 || workableRecipeMap.getMaxOutputs() > 6 || workableRecipeMap.getMaxFluidOutputs() > 6) {
+            yOffset = FONT_HEIGHT;
+        }
+
+        ModularUI.Builder builder = workableRecipeMap.createUITemplate(workable::getProgressPercent, importItems, exportItems, importFluids, exportFluids, yOffset)
             .widget(new LabelWidget(5, 5, getMetaFullName()))
-            .widget(new SlotWidget(chargerInventory, 0, 79, 62)
+            .widget(new SlotWidget(chargerInventory, 0, 79, 62 + yOffset)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.CHARGER_OVERLAY))
-            .widget(new ImageWidget(79, 42, 18, 18, GuiTextures.INDICATOR_NO_ENERGY)
+            .widget(new ImageWidget(79, 42 + yOffset, 18, 18, GuiTextures.INDICATOR_NO_ENERGY)
                 .setPredicate(workable::isHasNotEnoughEnergy))
-            .bindPlayerInventory(player.inventory);
+            .bindPlayerInventory(player.inventory, GuiTextures.SLOT, yOffset);
 
         int leftButtonStartX = 7;
 
         if (exportItems.getSlots() > 0) {
-            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62, 18, 18,
+            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
                 GuiTextures.BUTTON_ITEM_OUTPUT, this::isAutoOutputItems, this::setAutoOutputItems)
                 .setTooltipText("gregtech.gui.item_auto_output.tooltip"));
             leftButtonStartX += 18;
         }
         if (exportFluids.getTanks() > 0) {
-            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62, 18, 18,
+            builder.widget(new ToggleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
                 GuiTextures.BUTTON_FLUID_OUTPUT, this::isAutoOutputFluids, this::setAutoOutputFluids)
                 .setTooltipText("gregtech.gui.fluid_auto_output.tooltip"));
             leftButtonStartX += 18;
         }
 
-        builder.widget(new CycleButtonWidget(leftButtonStartX, 62, 18, 18,
+        builder.widget(new CycleButtonWidget(leftButtonStartX, 62 + yOffset, 18, 18,
                 workable.getAvailableOverclockingTiers(), workable::getOverclockTier, workable::setOverclockTier)
                 .setTooltipHoverString("gregtech.gui.overclock.description")
                 .setButtonTexture(GuiTextures.BUTTON_OVERCLOCK));

--- a/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SteamMetaTileEntity.java
@@ -119,6 +119,6 @@ public abstract class SteamMetaTileEntity extends MetaTileEntity {
             .widget(new LabelWidget(6, 6, getMetaFullName()))
             .widget(new ImageWidget(79, 42, 18, 18, getFullGuiTexture("not_enough_steam_%s"))
                 .setPredicate(() -> workableHandler.isHasNotEnoughEnergy()))
-            .bindPlayerInventory(player.inventory, BRONZE_SLOT_BACKGROUND_TEXTURE);
+            .bindPlayerInventory(player.inventory, BRONZE_SLOT_BACKGROUND_TEXTURE, 0);
     }
 }

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -271,8 +271,8 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return null;
     }
 
-    public ModularUI.Builder createJeiUITemplate(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
-        return createUITemplate(this::jeiProgressBar, importItems, exportItems, importFluids, exportFluids);
+    public ModularUI.Builder createJeiUITemplate(IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
+        return createUITemplate(this::jeiProgressBar, importItems, exportItems, importFluids, exportFluids, yOffset);
     }
 
     private double timer = 0;
@@ -283,17 +283,17 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     }
 
     //this DOES NOT include machine control widgets or binds player inventory
-    public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
-        ModularUI.Builder builder = ModularUI.defaultBuilder();
-        builder.widget(new ProgressWidget(progressSupplier, 78, 23, 20, 20, progressBarTexture, moveType));
-        addInventorySlotGroup(builder, importItems, importFluids, false);
-        addInventorySlotGroup(builder, exportItems, exportFluids, true);
+    public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
+        ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
+        builder.widget(new ProgressWidget(progressSupplier, 78, 23 + yOffset, 20, 20, progressBarTexture, moveType));
+        addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
+        addInventorySlotGroup(builder, exportItems, exportFluids, true, yOffset);
         if (this.specialTexture != null && this.specialTexturePosition != null)
             addSpecialTexture(builder);
         return builder;
     }
 
-    protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs) {
+    protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs, int yOffset) {
         int itemInputsCount = itemHandler.getSlots();
         int fluidInputsCount = fluidHandler.getTanks();
         boolean invertFluids = false;
@@ -307,7 +307,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = isOutputs ? 106 : 70 - itemSlotsToLeft * 18;
-        int startInputsY = 33 - (int) (itemSlotsToDown / 2.0 * 18);
+        int startInputsY = 33 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
         boolean wasGroupOutput = itemHandler.getSlots() + fluidHandler.getTanks() == 12;
         if (wasGroupOutput) startInputsY -= 9;
         for (int i = 0; i < itemSlotsToDown; i++) {
@@ -331,10 +331,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
                 for (int i = 0; i < fluidInputsCount; i++) {
                     int x = isOutputs ? startInputsX + 18 * (i % 3) : startInputsX + itemSlotsToLeft * 18 - 18 - 18 * (i % 3);
                     int y = startSpecY + (i / 3) * 18;
-                    if (itemHandler.getSlots() >= 9)
-                        addSlot(builder, x, y + 2, i, itemHandler, fluidHandler, !invertFluids, isOutputs);
-                    else
-                        addSlot(builder, x, y, i, itemHandler, fluidHandler, !invertFluids, isOutputs);
+                    addSlot(builder, x, y, i, itemHandler, fluidHandler, !invertFluids, isOutputs);
                 }
             }
         }

--- a/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
+++ b/src/main/java/gregtech/api/recipes/machines/RecipeMapAssemblyLine.java
@@ -32,7 +32,7 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
 
     @Override
     @Nonnull
-    public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids) {
+    public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
         ModularUI.Builder builder = new ModularUI.Builder(GuiTextures.BACKGROUND, 176, 216) {
             @Override
             public ModularUI.Builder bindPlayerInventory(InventoryPlayer inventoryPlayer) {
@@ -42,13 +42,13 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
 
         };
         builder.widget(new ProgressWidget(progressSupplier, 109, 22, 20, 20, this.progressBarTexture, this.moveType));
-        this.addInventorySlotGroup(builder, importItems, importFluids, false);
-        this.addInventorySlotGroup(builder, exportItems, exportFluids, true);
+        this.addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
+        this.addInventorySlotGroup(builder, exportItems, exportFluids, true, yOffset);
         return builder;
     }
 
     @Override
-    protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs) {
+    protected void addInventorySlotGroup(ModularUI.Builder builder, IItemHandlerModifiable itemHandler, FluidTankList fluidHandler, boolean isOutputs, int yOffset) {
         int itemInputsCount = itemHandler.getSlots();
         int fluidInputsCount = fluidHandler.getTanks();
         boolean invertFluids = false;
@@ -62,7 +62,7 @@ public class RecipeMapAssemblyLine<R extends RecipeBuilder<R>> extends RecipeMap
         int itemSlotsToLeft = inputSlotGrid[0];
         int itemSlotsToDown = inputSlotGrid[1];
         int startInputsX = isOutputs ? 138 : 101 - itemSlotsToLeft * 18;
-        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18);
+        int startInputsY = 32 - (int) (itemSlotsToDown / 2.0 * 18) + yOffset;
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityCokeOven.java
@@ -270,7 +270,7 @@ public class MetaTileEntityCokeOven extends MultiblockControllerBase {
                 .setBackgroundTexture(GuiTextures.FLUID_TANK_BACKGROUND)
                 .setOverlayTexture(GuiTextures.FLUID_TANK_OVERLAY)
                 .setContainerClicking(true, false))
-            .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT)
+            .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT, 0)
             .build(getHolder(), entityPlayer);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityPrimitiveBlastFurnace.java
@@ -406,7 +406,7 @@ public class MetaTileEntityPrimitiveBlastFurnace extends MultiblockControllerBas
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.INGOT_OVERLAY))
             .widget(new SlotWidget(exportItems, 1, 103, 24, true, false)
                 .setBackgroundTexture(GuiTextures.SLOT, GuiTextures.DUST_OVERLAY))
-            .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT)
+            .bindPlayerInventory(entityPlayer.inventory, GuiTextures.SLOT, 0)
             .build(getHolder(), entityPlayer);
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -289,7 +289,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
             .widget(new ImageWidget(43, 44, 18, 18)
                 .setImage(getGuiTexture("overlay_%s_fluid_container")))
 
-            .bindPlayerInventory(player.inventory, BRONZE_SLOT_BACKGROUND_TEXTURE);
+            .bindPlayerInventory(player.inventory, BRONZE_SLOT_BACKGROUND_TEXTURE, 0);
     }
 
     private int getBoilingCycleLength() {

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -35,6 +35,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     private final FluidTankList importFluids, exportFluids;
     private final IDrawable backgroundDrawable;
 
+    private final int FONT_HEIGHT = 9;
+
     public RecipeMapCategory(RecipeMap<?> recipeMap, IGuiHelper guiHelper) {
         this.recipeMap = recipeMap;
         FluidTank[] importFluidTanks = new FluidTank[recipeMap.getMaxFluidInputs()];
@@ -47,7 +49,9 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
             (importItems = new ItemStackHandler(recipeMap.getMaxInputs())),
             (exportItems = new ItemStackHandler(recipeMap.getMaxOutputs())),
             (importFluids = new FluidTankList(false, importFluidTanks)),
-            (exportFluids = new FluidTankList(false, exportFluidTanks))
+            (exportFluids = new FluidTankList(false, exportFluidTanks)),
+            (recipeMap.getMaxOutputs() > 6 || recipeMap.getMaxInputs() > 6 ||
+                    recipeMap.getMaxFluidOutputs() > 6 || recipeMap.getMaxFluidInputs() > 6) ? FONT_HEIGHT : 0
         ).build(new BlankUIHolder(), Minecraft.getMinecraft().player);
         this.modularUI.initWidgets();
         this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3);


### PR DESCRIPTION
**What:**
Remove the offset of the fluid slot in the assembler and adds the Machine title areas previously attempted by Tech in his GTCE PR.

**How solved:**
Adds a new method to be able to add an offset to the gui building and adjusts several methods to have an offset parameter.

**Outcome:**
Adds offset to the machine title in certain cases
