### PR TITLE
Quantum Tanks/Chests can now disallow input from their export face via screwdriver 

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -290,6 +290,9 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     @Override
     public boolean onWrenchClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
         if (!playerIn.isSneaking()) {
+            if (getOutputFacing() == facing || getFrontFacing() == facing) {
+                return false;
+            }
             if (!getWorld().isRemote) {
                 setOutputFacing(facing);
             }
@@ -347,20 +350,14 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             }
             return null;
         }
-     else if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
-        IItemHandler itemHandler = (side == getOutputFacing() && !isAllowInputFromOutputSide()) ? outputItemInventory : itemInventory;
-        if (itemHandler.getSlots() > 0) {
-            return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(itemHandler);
+        else if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+            IItemHandler itemHandler = (side == getOutputFacing() && !isAllowInputFromOutputSide()) ? outputItemInventory : itemInventory;
+            if (itemHandler.getSlots() > 0) {
+                return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(itemHandler);
+            }
+            return null;
         }
-        return null;
-    }
         return super.getCapability(capability, side);
-
-    }
-
-    @Override
-    public boolean canPlaceCoverOnSide(EnumFacing side) {
-        return true;
     }
 
     @Override

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -7,6 +7,8 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IActiveOutputSide;
+import gregtech.api.capability.impl.ItemHandlerProxy;
+import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
@@ -35,6 +37,7 @@ import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants.NBT;
+import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
@@ -58,6 +61,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     private static final String NBT_ITEMSTACK = "ItemStack";
     private static final String NBT_PARTIALSTACK = "PartialStack";
     private static final String NBT_ITEMCOUNT = "ItemAmount";
+    protected IItemHandler outputItemInventory;
 
     public MetaTileEntityQuantumChest(ResourceLocation metaTileEntityId, int tier, long maxStoredItems) {
         super(metaTileEntityId);
@@ -185,6 +189,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     protected void initializeInventory() {
         super.initializeInventory();
         this.itemInventory = new QuantumChestItemHandler();
+        this.outputItemInventory = new ItemHandlerProxy(new ItemStackHandler(0), exportItems);
     }
 
     @Override
@@ -342,16 +347,19 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
             }
             return null;
         }
+     else if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+        IItemHandler itemHandler = (side == getOutputFacing() && !isAllowInputFromOutputSide()) ? outputItemInventory : itemInventory;
+        if (itemHandler.getSlots() > 0) {
+            return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(itemHandler);
+        }
+        return null;
+    }
         return super.getCapability(capability, side);
 
     }
 
     @Override
     public boolean canPlaceCoverOnSide(EnumFacing side) {
-        //Done to prevent loops as output always acts as input
-        if (side == getOutputFacing()) {
-            return false;
-        }
         return true;
     }
 
@@ -381,6 +389,30 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     @Override
     public void clearMachineInventory(NonNullList<ItemStack> itemBuffer) {
         clearInventory(itemBuffer, importItems);
+    }
+
+    @Override
+    public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
+        EnumFacing hitFacing = ICoverable.determineGridSideHit(hitResult);
+        if (facing == getOutputFacing() || (hitFacing == getOutputFacing() && playerIn.isSneaking())) {
+            if (!getWorld().isRemote) {
+                if (isAllowInputFromOutputSide()) {
+                    setAllowInputFromOutputSide(false);
+                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"));
+                } else {
+                    setAllowInputFromOutputSide(true);
+                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"));
+                }
+            }
+            return true;
+        }
+        return super.onScrewdriverClick(playerIn, hand, facing, hitResult);
+    }
+    public void setAllowInputFromOutputSide(boolean allowInputFromOutputSide) {
+        this.allowInputFromOutputSide = allowInputFromOutputSide;
+        if (!getWorld().isRemote) {
+            markDirty();
+        }
     }
 
     private class QuantumChestItemHandler implements IItemHandler {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -7,7 +7,9 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IActiveOutputSide;
+import gregtech.api.capability.impl.FluidHandlerProxy;
 import gregtech.api.capability.impl.FluidTankList;
+import gregtech.api.cover.ICoverable;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
@@ -28,11 +30,14 @@ import net.minecraft.util.EnumHand;
 import net.minecraft.util.NonNullList;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
+import net.minecraft.util.text.TextComponentTranslation;
 import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTank;
+import net.minecraftforge.fluids.capability.CapabilityFluidHandler;
+import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -49,7 +54,8 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     private final ItemStackHandler containerInventory;
     private boolean autoOutputFluids;
     private EnumFacing outputFacing;
-    private final boolean allowInputFromOutputSide = true;
+    private boolean allowInputFromOutputSide = true;
+    protected IFluidHandler outputFluidInventory;
 
     public MetaTileEntityQuantumTank(ResourceLocation metaTileEntityId, int tier, int maxFluidCapacity) {
         super(metaTileEntityId);
@@ -71,6 +77,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         this.fluidInventory = fluidTank;
         this.importFluids = new FluidTankList(false, fluidTank);
         this.exportFluids = new FluidTankList(false, fluidTank);
+        this.outputFluidInventory = new FluidHandlerProxy(new FluidTankList(false), exportFluids);
     }
 
     @Override
@@ -235,7 +242,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
 
     @Override
     public boolean isAllowInputFromOutputSide() {
-        return true;
+        return allowInputFromOutputSide;
     }
 
     @Override
@@ -279,16 +286,20 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
             }
             return null;
         }
+        else if (capability == CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY) {
+            IFluidHandler fluidHandler = (side == getOutputFacing() && !isAllowInputFromOutputSide()) ? outputFluidInventory : fluidInventory;
+            if (fluidHandler.getTankProperties().length > 0) {
+                return CapabilityFluidHandler.FLUID_HANDLER_CAPABILITY.cast(fluidHandler);
+            }
+
+            return null;
+        }
         return super.getCapability(capability, side);
 
     }
 
     @Override
     public boolean canPlaceCoverOnSide(EnumFacing side) {
-        //Done to prevent loops as output always acts as input
-        if (side == getOutputFacing()) {
-            return false;
-        }
         return true;
     }
 
@@ -303,7 +314,30 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         return super.onWrenchClick(playerIn, hand, facing, hitResult);
     }
 
+    @Override
+    public boolean onScrewdriverClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
+        EnumFacing hitFacing = ICoverable.determineGridSideHit(hitResult);
+        if (facing == getOutputFacing() || (hitFacing == getOutputFacing() && playerIn.isSneaking())) {
+            if (!getWorld().isRemote) {
+                if (isAllowInputFromOutputSide()) {
+                    setAllowInputFromOutputSide(false);
+                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.disallow"));
+                } else {
+                    setAllowInputFromOutputSide(true);
+                    playerIn.sendMessage(new TextComponentTranslation("gregtech.machine.basic.input_from_output_side.allow"));
+                }
+            }
+            return true;
+        }
+        return super.onScrewdriverClick(playerIn, hand, facing, hitResult);
+    }
 
+    public void setAllowInputFromOutputSide(boolean allowInputFromOutputSide) {
+        this.allowInputFromOutputSide = allowInputFromOutputSide;
+        if (!getWorld().isRemote) {
+            markDirty();
+        }
+    }
     public void setAutoOutputFluids(boolean autoOutputFluids) {
         this.autoOutputFluids = autoOutputFluids;
         if (!getWorld().isRemote) {

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -161,11 +161,6 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     }
 
     @Override
-    public boolean hasFrontFacing() {
-        return false;
-    }
-
-    @Override
     public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
         Textures.VOLTAGE_CASINGS[tier].render(renderState, translation, ArrayUtils.add(pipeline,
                 new ColourMultiplier(GTUtility.convertRGBtoOpaqueRGBA_CL(getPaintingColorForRendering()))));
@@ -230,6 +225,14 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         return outputFacing == null ? EnumFacing.SOUTH : outputFacing;
     }
 
+    @Override
+    public void setFrontFacing(EnumFacing frontFacing) {
+        super.setFrontFacing(EnumFacing.UP);
+        if (this.outputFacing == null) {
+            //set initial output facing as opposite to front
+            setOutputFacing(frontFacing.getOpposite());
+        }
+    }
 
     @Override
     public boolean isAutoOutputItems() {
@@ -299,13 +302,11 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     }
 
     @Override
-    public boolean canPlaceCoverOnSide(EnumFacing side) {
-        return true;
-    }
-
-    @Override
     public boolean onWrenchClick(EntityPlayer playerIn, EnumHand hand, EnumFacing facing, CuboidRayTraceResult hitResult) {
         if (!playerIn.isSneaking()) {
+            if (getOutputFacing() == facing || getFrontFacing() == facing) {
+                return false;
+            }
             if (!getWorld().isRemote) {
                 setOutputFacing(facing);
             }
@@ -345,6 +346,4 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
             markDirty();
         }
     }
-
-
 }


### PR DESCRIPTION
**What:**
Fixes the screwdriver action of Quantum Tanks and Chests to allow and disallow input from their export face

**Outcome:**
when fixes a loop created with pipes, and allows for more control over tanks/chests.

**Additional info:**
I have also allowed covers to be placed on all sides of tanks/chests.