### PR TITLE
Add Highlighting to the Crafting Station

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
+++ b/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
@@ -11,6 +11,7 @@ import net.minecraftforge.items.ItemStackHandler;
 public class CraftingStationInputWidgetGroup extends AbstractWidgetGroup {
     protected CraftingRecipeResolver recipeResolver;
     protected short tintLocations;
+    public static final int LIGHT_RED = 0x66FF0000;
 
     public CraftingStationInputWidgetGroup(int x, int y, ItemStackHandler craftingGrid, CraftingRecipeResolver recipeResolver) {
         super(new Position(x, y));
@@ -32,7 +33,7 @@ public class CraftingStationInputWidgetGroup extends AbstractWidgetGroup {
             for (int i = 0; i < 9; i++) {
                 Widget widget = widgets.get(i);
                 if (widget instanceof PhantomSlotWidget && ((tintLocations >> i) & 1) == 0) { // In other words, is this slot usable?
-                    int color = 0x66FF0000;
+                    int color = LIGHT_RED;
 
                     PhantomSlotWidget phantomSlotWidget = (PhantomSlotWidget) widget;
                     drawSolidRect(phantomSlotWidget.getPosition().x, phantomSlotWidget.getPosition().y,

--- a/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
+++ b/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
@@ -37,7 +37,7 @@ public class CraftingStationInputWidgetGroup extends AbstractWidgetGroup {
 
                     PhantomSlotWidget phantomSlotWidget = (PhantomSlotWidget) widget;
                     drawSolidRect(phantomSlotWidget.getPosition().x, phantomSlotWidget.getPosition().y,
-                            phantomSlotWidget.getSize().getWidth(), phantomSlotWidget.getSize().getWidth(), color);
+                            phantomSlotWidget.getSize().getWidth() - 1, phantomSlotWidget.getSize().getWidth() - 1, color);
                 }
             }
         }

--- a/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
+++ b/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
@@ -32,7 +32,7 @@ public class CraftingStationInputWidgetGroup extends AbstractWidgetGroup {
             for (int i = 0; i < 9; i++) {
                 Widget widget = widgets.get(i);
                 if (widget instanceof PhantomSlotWidget && ((tintLocations >> i) & 1) == 0) { // In other words, is this slot usable?
-                    int color = 0x00005555;
+                    int color = 0x66FF0000;
 
                     PhantomSlotWidget phantomSlotWidget = (PhantomSlotWidget) widget;
                     drawSolidRect(phantomSlotWidget.getPosition().x, phantomSlotWidget.getPosition().y,
@@ -45,9 +45,18 @@ public class CraftingStationInputWidgetGroup extends AbstractWidgetGroup {
     @Override
     public void detectAndSendChanges() {
         super.detectAndSendChanges();
-        if (recipeResolver.getCachedRecipeData().attemptMatchRecipe() != tintLocations) {
-            this.tintLocations = recipeResolver.getCachedRecipeData().attemptMatchRecipe();
+        short newTintLocations = getTintLocations();
+        if (tintLocations != newTintLocations) {
+            this.tintLocations = newTintLocations;
             writeUpdateInfo(2, buffer -> buffer.writeShort(tintLocations));
+        }
+    }
+
+    private short getTintLocations() {
+        if(recipeResolver.getCachedRecipeData() != null) {
+            return recipeResolver.getCachedRecipeData().attemptMatchRecipe();
+        } else {
+            return 511;
         }
     }
 

--- a/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
+++ b/src/main/java/gregtech/api/gui/widgets/CraftingStationInputWidgetGroup.java
@@ -1,0 +1,60 @@
+package gregtech.api.gui.widgets;
+
+import gregtech.api.gui.GuiTextures;
+import gregtech.api.gui.IRenderContext;
+import gregtech.api.gui.Widget;
+import gregtech.api.util.Position;
+import gregtech.common.metatileentities.storage.CraftingRecipeResolver;
+import net.minecraft.network.PacketBuffer;
+import net.minecraftforge.items.ItemStackHandler;
+
+public class CraftingStationInputWidgetGroup extends AbstractWidgetGroup {
+    protected CraftingRecipeResolver recipeResolver;
+    protected short tintLocations;
+
+    public CraftingStationInputWidgetGroup(int x, int y, ItemStackHandler craftingGrid, CraftingRecipeResolver recipeResolver) {
+        super(new Position(x, y));
+
+        //crafting grid
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                this.addWidget(new PhantomSlotWidget(craftingGrid, j + i * 3, x + j * 18, y + i * 18).setBackgroundTexture(GuiTextures.SLOT));
+            }
+        }
+
+        this.recipeResolver = recipeResolver;
+    }
+
+    @Override
+    public void drawInBackground(int mouseX, int mouseY, IRenderContext context) {
+        super.drawInBackground(mouseX, mouseY, context);
+        if(this.widgets.size() == 9) { // In case someone added more...
+            for (int i = 0; i < 9; i++) {
+                Widget widget = widgets.get(i);
+                if (widget instanceof PhantomSlotWidget && ((tintLocations >> i) & 1) == 0) { // In other words, is this slot usable?
+                    int color = 0x00005555;
+
+                    PhantomSlotWidget phantomSlotWidget = (PhantomSlotWidget) widget;
+                    drawSolidRect(phantomSlotWidget.getPosition().x, phantomSlotWidget.getPosition().y,
+                            phantomSlotWidget.getSize().getWidth(), phantomSlotWidget.getSize().getWidth(), color);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void detectAndSendChanges() {
+        super.detectAndSendChanges();
+        if (recipeResolver.getCachedRecipeData().attemptMatchRecipe() != tintLocations) {
+            this.tintLocations = recipeResolver.getCachedRecipeData().attemptMatchRecipe();
+            writeUpdateInfo(2, buffer -> buffer.writeShort(tintLocations));
+        }
+    }
+
+    public void readUpdateInfo(int id, PacketBuffer buffer) {
+        super.readUpdateInfo(id, buffer);
+        if (id == 2) {
+            tintLocations = buffer.readShort();
+        }
+    }
+}

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -103,7 +103,7 @@ public class CachedRecipeData {
         if (currentStack.isEmpty()) {
             return true; //stack is empty, nothing to return
         }
-        ItemStackKey currentStackKey = new ItemStackKey(currentStack);
+        ItemStackKey currentStackKey = new ItemStackKey(currentStack.copy());
         if (simulateExtractItem(currentStackKey)) {
             //we can extract ingredient equal to the one in the crafting grid,
             //so just return it without searching equivalent
@@ -121,6 +121,7 @@ public class CachedRecipeData {
                     return true;
                 }
             }
+            inventory.setInventorySlotContents(slot, currentStack);
         }
         //nothing matched, so return null
         return false;

--- a/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CachedRecipeData.java
@@ -61,15 +61,17 @@ public class CachedRecipeData {
         return true;
     }
 
-    public boolean attemptMatchRecipe() {
-        this.ingredientsMatched = false;
+    public short attemptMatchRecipe() {
+        ingredientsMatched = true;
+        short itemsFound = 0;
         this.requiredItems.clear();
         for (int i = 0; i < inventory.getSizeInventory(); i++) {
-            if (!getIngredientEquivalent(i))
-                return false; //ingredient didn't match, return false
+            if (getIngredientEquivalent(i))
+                itemsFound += 1 << i; //ingredient was found, and indicate in the short of this fact
+            else
+                ingredientsMatched = false;
         }
-        this.ingredientsMatched = true;
-        return true;
+        return itemsFound;
     }
 
     public boolean checkRecipeValid() {
@@ -96,7 +98,7 @@ public class CachedRecipeData {
         return true;
     }
 
-    private boolean getIngredientEquivalent(int slot) {
+    public boolean getIngredientEquivalent(int slot) {
         ItemStack currentStack = inventory.getStackInSlot(slot);
         if (currentStack.isEmpty()) {
             return true; //stack is empty, nothing to return

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
@@ -171,6 +171,6 @@ public class CraftingRecipeResolver {
     }
 
     public CachedRecipeData getCachedRecipeData() {
-        return this.getCachedRecipeData();
+        return this.cachedRecipeData;
     }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
@@ -31,7 +31,6 @@ public class CraftingRecipeResolver {
     private final InventoryCrafting inventoryCrafting = new InventoryCrafting(new DummyContainer(), 3, 3);
     private IRecipe cachedRecipe = null;
     private final IInventory craftingResultInventory = new InventoryCraftResult();
-    private long timer = 0L;
     private CachedRecipeData cachedRecipeData = null;
     private int itemsCrafted = 0;
     private final CraftingRecipeMemory recipeMemory;
@@ -151,16 +150,13 @@ public class CraftingRecipeResolver {
     }
 
     public void update() {
-        //update item sources every second, it is enough
+        //update item sources every tick for fast tinting updates
         //if they are being modified, they will update themselves anyway
-        if (timer % 20 == 0L) {
-            this.itemSourceList.update();
-        }
+        this.itemSourceList.update();
         //update crafting inventory state
         if (updateInventoryCrafting()) {
             updateCurrentRecipe();
         }
-        this.timer++;
     }
 
     public void checkNeighbourInventories(BlockPos blockPos) {

--- a/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/CraftingRecipeResolver.java
@@ -169,4 +169,8 @@ public class CraftingRecipeResolver {
             this.itemSourceList.addItemHandler(itemSource);
         }
     }
+
+    public CachedRecipeData getCachedRecipeData() {
+        return this.getCachedRecipeData();
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -153,11 +153,8 @@ public class MetaTileEntityWorkbench extends MetaTileEntity {
         widgetGroup.addWidget(new CraftingSlotWidget(recipeResolver, 0, 88 - 9, 44 - 9));
 
         //crafting grid
-        for (int i = 0; i < 3; ++i) {
-            for (int j = 0; j < 3; ++j) {
-                widgetGroup.addWidget(new PhantomSlotWidget(craftingGrid, j + i * 3, 8 + j * 18, 17 + i * 18).setBackgroundTexture(GuiTextures.SLOT));
-            }
-        }
+        widgetGroup.addWidget(new CraftingStationInputWidgetGroup(5, 0, craftingGrid, recipeResolver));
+
         Supplier<String> textSupplier = () -> Integer.toString(recipeResolver.getItemsCrafted());
         widgetGroup.addWidget(new SimpleTextWidget(88, 44 + 20, "", textSupplier));
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityWorkbench.java
@@ -153,7 +153,7 @@ public class MetaTileEntityWorkbench extends MetaTileEntity {
         widgetGroup.addWidget(new CraftingSlotWidget(recipeResolver, 0, 88 - 9, 44 - 9));
 
         //crafting grid
-        widgetGroup.addWidget(new CraftingStationInputWidgetGroup(5, 0, craftingGrid, recipeResolver));
+        widgetGroup.addWidget(new CraftingStationInputWidgetGroup(5, 8, craftingGrid, recipeResolver));
 
         Supplier<String> textSupplier = () -> Integer.toString(recipeResolver.getItemsCrafted());
         widgetGroup.addWidget(new SimpleTextWidget(88, 44 + 20, "", textSupplier));


### PR DESCRIPTION
**What:**
In earlier versions, it would be quite difficult to detect whether or not one had all of the items to craft something in a crafting station.

**How solved:**
This adds a new specialized group of widgets, CraftingStationInputWidgetGroup, that detects which items are missing in the cached recipe and tints its slots accordingly.

**Outcome:**
Adds tinting to Crafting Station crafting slots to show which items are missing.

**Additional info:**

https://user-images.githubusercontent.com/80226372/129286608-dee7a7cb-62bc-4e5a-95a1-17e8dac5bc7a.mp4

**Possible compatibility issue:**
I did have to change the return type of attemptMatchRecipe in CachedRecipeData, although nothing actually uses that return in GTCEu, and attemptMatchRecipe() == 511 should give the same output as before. 