### PR TITLE
Made material tool enchantability not implicitly tied to icon sets

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -20,7 +20,6 @@ import gregtech.api.items.metaitem.stats.IItemContainerItemProvider;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.MaterialRegistry;
 import gregtech.api.unification.material.Materials;
-import gregtech.api.unification.material.info.MaterialIconSet;
 import gregtech.api.unification.material.properties.DustProperty;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.material.properties.ToolProperty;
@@ -474,28 +473,6 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
             return metaToolValueItem.toolStats.canApplyEnchantment(stack, enchantment);
         }
         return false;
-    }
-
-    @Deprecated
-    public static int getMaterialEnchantability(Material material) {
-        if (material.getMaterialIconSet() == MaterialIconSet.SHINY ||
-                material.getMaterialIconSet() == MaterialIconSet.RUBY) {
-            return 33; //all shiny metals have gold enchantability
-        } else if (material.getMaterialIconSet() == MaterialIconSet.DULL ||
-                material.getMaterialIconSet() == MaterialIconSet.METALLIC) {
-            return 21; //dull metals have iron enchantability
-        } else if (material.getMaterialIconSet() == MaterialIconSet.GEM_VERTICAL ||
-                material.getMaterialIconSet() == MaterialIconSet.GEM_HORIZONTAL ||
-                material.getMaterialIconSet() == MaterialIconSet.DIAMOND ||
-                material.getMaterialIconSet() == MaterialIconSet.OPAL ||
-                material.getMaterialIconSet() == MaterialIconSet.NETHERSTAR) {
-            return 15; //standard gems have diamond enchantability
-        } else if (material.getMaterialIconSet() == MaterialIconSet.WOOD ||
-                material.getMaterialIconSet() == MaterialIconSet.ROUGH ||
-                material.getMaterialIconSet() == MaterialIconSet.FINE) {
-            return 11; //wood and stone has their default enchantability
-        }
-        return 10; //otherwise return lowest enchantability
     }
 
     @Override

--- a/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
+++ b/src/main/java/gregtech/api/items/toolitem/ToolMetaItem.java
@@ -464,8 +464,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
 
     @Override
     public int getItemEnchantability(ItemStack stack) {
-        Material primaryMaterial = getToolMaterial(stack);
-        return getMaterialEnchantability(primaryMaterial);
+        return getToolMaterial(stack).getProperty(PropertyKey.TOOL).toolEnchantability;
     }
 
     @Override
@@ -477,6 +476,7 @@ public class ToolMetaItem<T extends ToolMetaItem<?>.MetaToolValueItem> extends M
         return false;
     }
 
+    @Deprecated
     public static int getMaterialEnchantability(Material material) {
         if (material.getMaterialIconSet() == MaterialIconSet.SHINY ||
                 material.getMaterialIconSet() == MaterialIconSet.RUBY) {

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -667,8 +667,8 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
-        public Builder toolStats(float speed, float damage, int durability) {
-            properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability));
+        public Builder toolStats(float speed, float damage, int durability, int enchantability) {
+            properties.setProperty(PropertyKey.TOOL, new ToolProperty(speed, damage, durability, enchantability));
             return this;
         }
 

--- a/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/ElementMaterials.java
@@ -23,7 +23,7 @@ public class ElementMaterials {
                 .color(0x80C8F0)
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR, GENERATE_RING, GENERATE_FRAME, GENERATE_SPRING, GENERATE_SPRING_SMALL)
                 .element(Elements.Al)
-                .toolStats(10.0f, 2.0f, 128)
+                .toolStats(10.0f, 2.0f, 128, 21)
                 .cableProperties(GTValues.V[4], 1, 1)
                 .fluidPipeProperties(1166, 35, true)
                 .blastTemp(1700)
@@ -154,7 +154,7 @@ public class ElementMaterials {
                 .color(0xFFE6E6).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE)
                 .element(Elements.Cr)
-                .toolStats(12.0f, 3.0f, 512)
+                .toolStats(12.0f, 3.0f, 512, 33)
                 .fluidPipeProperties(2725, 40, true)
                 .blastTemp(1700)
                 .build();
@@ -164,7 +164,7 @@ public class ElementMaterials {
                 .color(0x5050FA).iconSet(METALLIC)
                 .flags(STD_METAL, GENERATE_GEAR)
                 .element(Elements.Co)
-                .toolStats(10.0f, 3.0f, 256)
+                .toolStats(10.0f, 3.0f, 256, 21)
                 .cableProperties(GTValues.V[1], 2, 2)
                 .itemPipeProperties(2560, 2.0f)
                 .build();
@@ -348,7 +348,7 @@ public class ElementMaterials {
                 .color(0xF0F0F5)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE)
                 .element(Elements.Ir)
-                .toolStats(7.0f, 3.0f, 2560)
+                .toolStats(7.0f, 3.0f, 2560, 21)
                 .fluidPipeProperties(3398, 140, true)
                 .blastTemp(2719)
                 .build();
@@ -359,7 +359,7 @@ public class ElementMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_DENSE, GENERATE_FRAME, GENERATE_ROTOR, GENERATE_SMALL_GEAR,
                         GENERATE_SPRING, GENERATE_SPRING_SMALL, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, BLAST_FURNACE_CALCITE_TRIPLE)
                 .element(Elements.Fe)
-                .toolStats(7.0f, 2.5f, 256)
+                .toolStats(7.0f, 2.5f, 256, 21)
                 .cableProperties(GTValues.V[2], 2, 3)
                 .build();
 
@@ -429,7 +429,7 @@ public class ElementMaterials {
                 .color(0xFAFAFA)
                 .flags(STD_METAL, GENERATE_FOIL)
                 .element(Elements.Mn)
-                .toolStats(7.0f, 2.0f, 512)
+                .toolStats(7.0f, 2.0f, 512, 21)
                 .build();
 
         Meitnerium = new Material.Builder(62, "meitnerium")
@@ -448,7 +448,7 @@ public class ElementMaterials {
                 .ingot().fluid().ore()
                 .color(0xB4B4DC).iconSet(SHINY)
                 .element(Elements.Mo)
-                .toolStats(7.0f, 2.0f, 512)
+                .toolStats(7.0f, 2.0f, 512, 33)
                 .build();
 
         Moscovium = new Material.Builder(65, "moscovium")
@@ -462,7 +462,7 @@ public class ElementMaterials {
                 .color(0x646464).iconSet(METALLIC)
                 .flags(STD_METAL, GENERATE_ROD)
                 .element(Elements.Nd)
-                .toolStats(7.0f, 2.0f, 512)
+                .toolStats(7.0f, 2.0f, 512, 21)
                 .blastTemp(1297)
                 .build();
 
@@ -526,7 +526,7 @@ public class ElementMaterials {
                 .color(0x3232FF).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_DENSE)
                 .element(Elements.Os)
-                .toolStats(16.0f, 4.0f, 1280)
+                .toolStats(16.0f, 4.0f, 1280, 21)
                 .cableProperties(GTValues.V[5], 4, 2)
                 .itemPipeProperties(256, 8.0f)
                 .blastTemp(3306)
@@ -543,7 +543,7 @@ public class ElementMaterials {
                 .color(0x808080).iconSet(SHINY)
                 .flags(EXT2_METAL)
                 .element(Elements.Pd)
-                .toolStats(8.0f, 2.0f, 512)
+                .toolStats(8.0f, 2.0f, 512, 33)
                 .cableProperties(GTValues.V[5], 2, 1)
                 .blastTemp(1228)
                 .build();
@@ -772,7 +772,7 @@ public class ElementMaterials {
                 .color(0x001E00).iconSet(SHINY)
                 .flags(STD_METAL)
                 .element(Elements.Th)
-                .toolStats(6.0f, 2.0f, 512)
+                .toolStats(6.0f, 2.0f, 512, 33)
                 .build();
 
         Thallium = new Material.Builder(110, "thallium")
@@ -803,7 +803,7 @@ public class ElementMaterials {
                 .color(0xDCA0F0).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_SPRING, GENERATE_FRAME, GENERATE_DENSE)
                 .element(Elements.Ti)
-                .toolStats(7.0f, 3.0f, 1600)
+                .toolStats(7.0f, 3.0f, 1600, 21)
                 .cableProperties(GTValues.V[4], 4, 2)
                 .fluidPipeProperties(2426, 80, true)
                 .blastTemp(1941)
@@ -820,7 +820,7 @@ public class ElementMaterials {
                 .color(0x323232).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_SPRING, GENERATE_SPRING_SMALL)
                 .element(Elements.W)
-                .toolStats(7.0f, 3.0f, 2560)
+                .toolStats(7.0f, 3.0f, 2560, 21)
                 .cableProperties(GTValues.V[5], 2, 2)
                 .fluidPipeProperties(4618, 90, true)
                 .blastTemp(3000)
@@ -831,7 +831,7 @@ public class ElementMaterials {
                 .color(0x32F032).iconSet(METALLIC)
                 .flags(STD_METAL)
                 .element(Elements.U238)
-                .toolStats(6.0f, 3.0f, 512)
+                .toolStats(6.0f, 3.0f, 512, 21)
                 .build();
 
         Uranium235 = new Material.Builder(117, "uranium235")
@@ -839,7 +839,7 @@ public class ElementMaterials {
                 .color(0x46FA46).iconSet(SHINY)
                 .flags(STD_METAL, GENERATE_ROD)
                 .element(Elements.U235)
-                .toolStats(6.0f, 3.0f, 512)
+                .toolStats(6.0f, 3.0f, 512, 33)
                 .build();
 
         Vanadium = new Material.Builder(118, "vanadium")
@@ -892,7 +892,7 @@ public class ElementMaterials {
                 .color(0x323232).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FOIL, GENERATE_SPRING)
                 .element(Elements.Nq)
-                .toolStats(6.0f, 4.0f, 1280)
+                .toolStats(6.0f, 4.0f, 1280, 21)
                 .cableProperties(GTValues.V[7], 2, 2)
                 .fluidPipeProperties(19200, 1500, true)
                 .blastTemp(5400)
@@ -903,7 +903,7 @@ public class ElementMaterials {
                 .color(0x3C3C3C).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .element(Elements.Nq1)
-                .toolStats(6.0f, 4.0f, 1280)
+                .toolStats(6.0f, 4.0f, 1280, 21)
                 .blastTemp(4500)
                 .build();
 
@@ -920,7 +920,7 @@ public class ElementMaterials {
                 .color(0xFAFAFA)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME)
                 .element(Elements.Nt)
-                .toolStats(24.0f, 12.0f, 655360)
+                .toolStats(24.0f, 12.0f, 655360, 21)
                 .fluidPipeProperties(1000000, 2800, true)
                 .build();
 
@@ -929,7 +929,7 @@ public class ElementMaterials {
                 .color(0x600000).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FRAME)
                 .element(Elements.Tr)
-                .toolStats(20.0f, 6.0f, 10240)
+                .toolStats(20.0f, 6.0f, 10240, 21)
                 .build();
 
         Duranium = new Material.Builder(129, "duranium")
@@ -937,7 +937,7 @@ public class ElementMaterials {
                 .color(0x4BAFAF).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FOIL)
                 .element(Elements.Dr)
-                .toolStats(16.0f, 5.0f, 5120)
+                .toolStats(16.0f, 5.0f, 5120, 21)
                 .cableProperties(GTValues.V[8], 1, 8)
                 .fluidPipeProperties(100000, 2000, true)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -67,7 +67,7 @@ public class FirstDegreeMaterials {
                 .color(0x7B96DC).iconSet(GEM_HORIZONTAL)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Aluminium, 2, Silicon, 1, Fluorine, 2, Hydrogen, 2, Oxygen, 6)
-                .toolStats(7.0f, 3.0f, 256)
+                .toolStats(7.0f, 3.0f, 256, 15)
                 .build();
 
         Bone = new Material.Builder(258, "bone")
@@ -82,7 +82,7 @@ public class FirstDegreeMaterials {
                 .color(0xFFB400).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_RING)
                 .components(Zinc, 1, Copper, 3)
-                .toolStats(8.0f, 3.0f, 152)
+                .toolStats(8.0f, 3.0f, 152, 21)
                 .itemPipeProperties(2048, 1)
                 .build();
 
@@ -91,7 +91,7 @@ public class FirstDegreeMaterials {
                 .color(0xFF8000).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_FRAME)
                 .components(Tin, 1, Copper, 3)
-                .toolStats(6.0f, 2.5f, 192)
+                .toolStats(6.0f, 2.5f, 192, 21)
                 .fluidPipeProperties(1696, 20, true)
                 .build();
 
@@ -200,7 +200,7 @@ public class FirstDegreeMaterials {
                 .color(0xC8FFFF).iconSet(DIAMOND)
                 .flags(GENERATE_BOLT_SCREW, GENERATE_LENS, GENERATE_GEAR, NO_SMASHING, NO_SMELTING, FLAMMABLE,
                         HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
-                .toolStats(8.0f, 3.0f, 1280)
+                .toolStats(8.0f, 3.0f, 1280, 15)
                 .build();
 
         Electrum = new Material.Builder(277, "electrum")
@@ -217,7 +217,7 @@ public class FirstDegreeMaterials {
                 .color(0x50FF50).iconSet(EMERALD)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES, GENERATE_PLATE)
                 .components(Beryllium, 3, Aluminium, 2, Silicon, 6, Oxygen, 18)
-                .toolStats(10.0f, 2.0f, 368)
+                .toolStats(10.0f, 2.0f, 368, 15)
                 .build();
 
         Galena = new Material.Builder(279, "galena")
@@ -238,7 +238,7 @@ public class FirstDegreeMaterials {
                 .color(0x64C882).iconSet(GEM_HORIZONTAL)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Aluminium, 2, Oxygen, 3)
-                .toolStats(8.0f, 3.0f, 368)
+                .toolStats(8.0f, 3.0f, 368, 15)
                 .build();
 
         Grossular = new Material.Builder(282, "grossular")
@@ -280,7 +280,7 @@ public class FirstDegreeMaterials {
                 .color(0xB4B478).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_RING, GENERATE_FRAME)
                 .components(Iron, 2, Nickel, 1)
-                .toolStats(7.0f, 3.0f, 512)
+                .toolStats(7.0f, 3.0f, 512, 21)
                 .addDefaultEnchant(Enchantments.BANE_OF_ARTHROPODS, 3)
                 .fluidPipeProperties(2395, 40, true)
                 .build();
@@ -306,7 +306,7 @@ public class FirstDegreeMaterials {
                 .color(0xC8BEFF)
                 .flags(EXT2_METAL)
                 .components(Magnesium, 1, Aluminium, 2)
-                .toolStats(6.0f, 2.0f, 256)
+                .toolStats(6.0f, 2.0f, 256, 21)
                 .itemPipeProperties(1024, 2)
                 .build();
 
@@ -374,7 +374,7 @@ public class FirstDegreeMaterials {
                 .color(0xC8B4B4).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_RING, BLAST_FURNACE_CALCITE_TRIPLE)
                 .components(Iron, 1)
-                .toolStats(6.0f, 4.0f, 384)
+                .toolStats(6.0f, 4.0f, 384, 21)
                 .build();
 
         SterlingSilver = new Material.Builder(300, "sterling_silver")
@@ -382,7 +382,7 @@ public class FirstDegreeMaterials {
                 .color(0xFADCE1).iconSet(SHINY)
                 .flags(EXT2_METAL)
                 .components(Copper, 1, Silver, 4)
-                .toolStats(13.0f, 2.0f, 196)
+                .toolStats(13.0f, 2.0f, 196, 33)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1700)
                 .build();
@@ -392,7 +392,7 @@ public class FirstDegreeMaterials {
                 .color(0xFFE61E).iconSet(SHINY)
                 .flags(EXT2_METAL)
                 .components(Copper, 1, Gold, 4)
-                .toolStats(14.0f, 2.0f, 152)
+                .toolStats(14.0f, 2.0f, 152, 33)
                 .addDefaultEnchant(Enchantments.SMITE, 4)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(1600)
@@ -403,7 +403,7 @@ public class FirstDegreeMaterials {
                 .color(0x64327D)
                 .flags(EXT2_METAL)
                 .components(Gold, 1, Silver, 1, Copper, 3)
-                .toolStats(12.0f, 2.0f, 256)
+                .toolStats(12.0f, 2.0f, 256, 21)
                 .addDefaultEnchant(Enchantments.SMITE, 2)
                 .itemPipeProperties(1024, 2)
                 .blastTemp(2000)
@@ -414,7 +414,7 @@ public class FirstDegreeMaterials {
                 .color(0x647D7D)
                 .flags(EXT2_METAL)
                 .components(Bismuth, 1, Zinc, 1, Copper, 3)
-                .toolStats(8.0f, 3.0f, 256)
+                .toolStats(8.0f, 3.0f, 256, 21)
                 .addDefaultEnchant(Enchantments.BANE_OF_ARTHROPODS, 5)
                 .blastTemp(1100)
                 .build();
@@ -465,7 +465,7 @@ public class FirstDegreeMaterials {
                 .color(0xFF6464).iconSet(RUBY)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT)
                 .components(Chrome, 1, Aluminium, 2, Oxygen, 3)
-                .toolStats(8.5f, 3.0f, 256)
+                .toolStats(8.5f, 3.0f, 256, 33)
                 .build();
 
         Salt = new Material.Builder(312, "salt")
@@ -487,7 +487,7 @@ public class FirstDegreeMaterials {
                 .color(0x6464C8).iconSet(GEM_VERTICAL)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Aluminium, 2, Oxygen, 3)
-                .toolStats(7.5f, 4.0f, 256)
+                .toolStats(7.5f, 4.0f, 256, 15)
                 .build();
 
         Scheelite = new Material.Builder(315, "scheelite")
@@ -508,7 +508,7 @@ public class FirstDegreeMaterials {
                 .ingot(4).fluid()
                 .color(0x755280).iconSet(METALLIC)
                 .components(Americium, 2, Titanium, 1)
-                .toolStats(6.0f, 6.0f, 2200)
+                .toolStats(6.0f, 6.0f, 2200, 21)
                 .itemPipeProperties(32, 128)
                 .cableProperties(GTValues.V[10], 8, 16)
                 .blastTemp(10400)
@@ -553,7 +553,7 @@ public class FirstDegreeMaterials {
                 .color(0xC8C8DC).iconSet(SHINY)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_LONG_ROD)
                 .components(Iron, 7, Chrome, 1, Manganese, 1, Nickel, 1)
-                .toolStats(7.0f, 4.0f, 480)
+                .toolStats(7.0f, 4.0f, 480, 33)
                 .fluidPipeProperties(2428, 60, true)
                 .blastTemp(1700)
                 .build();
@@ -564,7 +564,7 @@ public class FirstDegreeMaterials {
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_DENSE, GENERATE_SPRING,
                         GENERATE_SPRING_SMALL, GENERATE_FRAME, DISABLE_DECOMPOSITION)
                 .components(Iron, 1)
-                .toolStats(6.0f, 3.0f, 512)
+                .toolStats(6.0f, 3.0f, 512, 21)
                 .fluidPipeProperties(2557, 40, true)
                 .cableProperties(GTValues.V[4], 2, 2)
                 .blastTemp(1000)
@@ -582,7 +582,7 @@ public class FirstDegreeMaterials {
                 .color(0x4000C8).iconSet(GEM_VERTICAL)
                 .flags(EXT_METAL, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Calcium, 2, Aluminium, 3, Silicon, 3, Hydrogen, 1)
-                .toolStats(7.0f, 2.0f, 256)
+                .toolStats(7.0f, 2.0f, 256, 15)
                 .build();
 
         Tetrahedrite = new Material.Builder(327, "tetrahedrite")
@@ -604,7 +604,7 @@ public class FirstDegreeMaterials {
                 .color(0xFF8000).iconSet(GEM_HORIZONTAL)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(Aluminium, 2, Silicon, 1, Fluorine, 1, Hydrogen, 2)
-                .toolStats(7.0f, 2.0f, 256)
+                .toolStats(7.0f, 2.0f, 256, 15)
                 .build();
 
         Tungstate = new Material.Builder(330, "tungstate")
@@ -619,7 +619,7 @@ public class FirstDegreeMaterials {
                 .color(0xB4B4E6).iconSet(SHINY)
                 .flags(EXT2_METAL)
                 .components(Cobalt, 5, Chrome, 2, Nickel, 1, Molybdenum, 1)
-                .toolStats(9.0f, 4.0f, 2048)
+                .toolStats(9.0f, 4.0f, 2048, 33)
                 .itemPipeProperties(128, 16)
                 .blastTemp(2700)
                 .build();
@@ -652,7 +652,7 @@ public class FirstDegreeMaterials {
                 .color(0xC8B4B4).iconSet(METALLIC)
                 .flags(EXT2_METAL, MORTAR_GRINDABLE, GENERATE_RING, GENERATE_LONG_ROD, DISABLE_DECOMPOSITION, BLAST_FURNACE_CALCITE_TRIPLE)
                 .components(Iron, 1)
-                .toolStats(6.0f, 3.5f, 384)
+                .toolStats(6.0f, 3.5f, 384, 21)
                 .fluidPipeProperties(2387, 30, true)
                 .build();
         Iron.getProperty(PropertyKey.INGOT).setSmeltingInto(WroughtIron);
@@ -725,7 +725,7 @@ public class FirstDegreeMaterials {
                 .color(0x6464FF).iconSet(METALLIC)
                 .flags(EXT2_METAL)
                 .components(Iridium, 3, Osmium, 1)
-                .toolStats(9.0f, 3.0f, 3152)
+                .toolStats(9.0f, 3.0f, 3152, 21)
                 .itemPipeProperties(64, 32)
                 .blastTemp(2500)
                 .build();
@@ -1054,7 +1054,7 @@ public class FirstDegreeMaterials {
                 .color(0x330066).iconSet(METALLIC)
                 .flags(EXT2_METAL)
                 .components(Tungsten, 1, Carbon, 1)
-                .toolStats(12.0f, 4.0f, 1280)
+                .toolStats(12.0f, 4.0f, 1280, 21)
                 .fluidPipeProperties(7568, 125, true)
                 .blastTemp(2460)
                 .build();

--- a/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/HigherDegreeMaterials.java
@@ -37,7 +37,7 @@ public class HigherDegreeMaterials {
                 .color(0x8C6464).iconSet(METALLIC)
                 .flags(EXT_METAL)
                 .components(SterlingSilver, 1, BismuthBronze, 1, Steel, 2, BlackSteel, 4)
-                .toolStats(7.0f, 4.5f, 896)
+                .toolStats(7.0f, 4.5f, 896, 21)
                 .blastTemp(1300)
                 .build();
 
@@ -46,7 +46,7 @@ public class HigherDegreeMaterials {
                 .color(0x64648C).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FRAME, GENERATE_GEAR)
                 .components(RoseGold, 1, Brass, 1, Steel, 2, BlackSteel, 4)
-                .toolStats(7.5f, 5.0f, 1024)
+                .toolStats(7.5f, 5.0f, 1024, 21)
                 .blastTemp(1400)
                 .build();
 
@@ -82,7 +82,7 @@ public class HigherDegreeMaterials {
                 .color(0x999900).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME, GENERATE_SPRING)
                 .components(TungstenSteel, 5, Chrome, 1, Molybdenum, 2, Vanadium, 1)
-                .toolStats(10.0f, 5.5f, 4000)
+                .toolStats(10.0f, 5.5f, 4000, 21)
                 .cableProperties(GTValues.V[6], 4, 2)
                 .blastTemp(4200)
                 .build();
@@ -110,7 +110,7 @@ public class HigherDegreeMaterials {
                 .color(0x336600).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_FRAME)
                 .components(HSSG, 6, Cobalt, 1, Manganese, 1, Silicon, 1)
-                .toolStats(10.0f, 8.0f, 5120)
+                .toolStats(10.0f, 8.0f, 5120, 21)
                 .blastTemp(5000)
                 .build();
 
@@ -119,7 +119,7 @@ public class HigherDegreeMaterials {
                 .color(0x660033).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_SMALL_GEAR)
                 .components(HSSG, 6, Iridium, 2, Osmium, 1)
-                .toolStats(15.0f, 7.0f, 3000)
+                .toolStats(15.0f, 7.0f, 3000, 21)
                 .blastTemp(5000)
                 .build();
 
@@ -128,7 +128,7 @@ public class HigherDegreeMaterials {
                 .color(0xf2ef27).iconSet(METALLIC)
                 .flags(EXT2_METAL)
                 .components(Electrum, 1, NaquadahAlloy, 1, BlueSteel, 1, RedSteel, 1)
-                .toolStats(11.0f, 6.0f, 2100)
+                .toolStats(11.0f, 6.0f, 2100, 21)
                 .cableProperties(GTValues.V[8], 3, 2)
                 .itemPipeProperties(128, 16)
                 .blastTemp(9000)

--- a/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/SecondDegreeMaterials.java
@@ -43,7 +43,7 @@ public class SecondDegreeMaterials {
                 .color(0x96FF96).iconSet(RUBY)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_PLATE)
                 .components(Magnesium, 2, Iron, 1, SiliconDioxide, 2)
-                .toolStats(7.5f, 3.0f, 312)
+                .toolStats(7.5f, 3.0f, 312, 33)
                 .build();
 
         Opal = new Material.Builder(2005, "opal")
@@ -51,7 +51,7 @@ public class SecondDegreeMaterials {
                 .color(0x0000FF).iconSet(OPAL)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING, GENERATE_LENS)
                 .components(SiliconDioxide, 1)
-                .toolStats(7.5f, 3.0f, 312)
+                .toolStats(7.5f, 3.0f, 312, 15)
                 .build();
 
         Amethyst = new Material.Builder(2006, "amethyst")
@@ -59,7 +59,7 @@ public class SecondDegreeMaterials {
                 .color(0xD232D2).iconSet(RUBY)
                 .flags(NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, GENERATE_LENS)
                 .components(SiliconDioxide, 4, Iron, 1)
-                .toolStats(7.5f, 3.0f, 312)
+                .toolStats(7.5f, 3.0f, 312, 33)
                 .build();
 
         Lapis = new Material.Builder(2007, "lapis")
@@ -96,7 +96,7 @@ public class SecondDegreeMaterials {
                 .color(0x646464).iconSet(METALLIC)
                 .flags(EXT_METAL, GENERATE_FINE_WIRE)
                 .components(Nickel, 1, BlackBronze, 1, Steel, 3)
-                .toolStats(6.5f, 6.5f, 768)
+                .toolStats(6.5f, 6.5f, 768, 21)
                 .cableProperties(GTValues.V[4], 3, 2)
                 .blastTemp(1200)
                 .build();
@@ -106,7 +106,7 @@ public class SecondDegreeMaterials {
                 .color(0x6E6E6E).iconSet(METALLIC)
                 .flags(EXT_METAL)
                 .components(Steel, 1)
-                .toolStats(8.0f, 5.0f, 1280)
+                .toolStats(8.0f, 5.0f, 1280, 21)
                 .blastTemp(1500)
                 .build();
 
@@ -115,7 +115,7 @@ public class SecondDegreeMaterials {
                 .color(0x6464A0).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_ROTOR, GENERATE_SMALL_GEAR, GENERATE_DENSE, GENERATE_FRAME, GENERATE_SPRING)
                 .components(Steel, 1, Tungsten, 1)
-                .toolStats(8.0f, 4.0f, 2560)
+                .toolStats(8.0f, 4.0f, 2560, 21)
                 .fluidPipeProperties(7568, 100, true)
                 .cableProperties(GTValues.V[5], 3, 2)
                 .blastTemp(3000)
@@ -126,7 +126,7 @@ public class SecondDegreeMaterials {
                 .color(0xB4B4A0).iconSet(METALLIC)
                 .flags(EXT2_METAL)
                 .components(Brass, 7, Aluminium, 1, Cobalt, 1)
-                .toolStats(8.0f, 2.0f, 256)
+                .toolStats(8.0f, 2.0f, 256, 21)
                 .itemPipeProperties(2048, 1)
                 .build();
 
@@ -142,7 +142,7 @@ public class SecondDegreeMaterials {
                 .color(0xC85050).iconSet(RUBY)
                 .flags(STD_SOLID, GENERATE_LENS, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Pyrope, 3, Almandine, 5, Spessartine, 8)
-                .toolStats(7.5f, 3.0f, 156)
+                .toolStats(7.5f, 3.0f, 156, 33)
                 .build();
 
         GarnetYellow = new Material.Builder(2017, "garnet_yellow")
@@ -150,7 +150,7 @@ public class SecondDegreeMaterials {
                 .color(0xC8C850).iconSet(RUBY)
                 .flags(STD_SOLID, GENERATE_LENS, NO_SMASHING, NO_SMELTING, HIGH_SIFTER_OUTPUT, DECOMPOSITION_BY_CENTRIFUGING)
                 .components(Andradite, 5, Grossular, 8, Uvarovite, 3)
-                .toolStats(7.5f, 3.0f, 156)
+                .toolStats(7.5f, 3.0f, 156, 33)
                 .build();
 
         Marble = new Material.Builder(2018, "marble")
@@ -280,7 +280,7 @@ public class SecondDegreeMaterials {
                 .color(0xc0c0c0).iconSet(METALLIC)
                 .flags(EXT2_METAL)
                 .components(Vanadium, 1, Chrome, 1, Steel, 7)
-                .toolStats(7.0f, 3.0f, 1920)
+                .toolStats(7.0f, 3.0f, 1920, 21)
                 .fluidPipeProperties(2073, 100, true)
                 .blastTemp(1453)
                 .build();
@@ -321,7 +321,7 @@ public class SecondDegreeMaterials {
                 .color(0x282828).iconSet(METALLIC)
                 .flags(EXT2_METAL, GENERATE_SPRING)
                 .components(Naquadah, 1, Osmiridium, 1)
-                .toolStats(8.0f, 5.0f, 5120)
+                .toolStats(8.0f, 5.0f, 5120, 21)
                 .cableProperties(GTValues.V[8], 2, 4)
                 .blastTemp(7200)
                 .build();
@@ -370,7 +370,7 @@ public class SecondDegreeMaterials {
                 .gem(1)
                 .color(0x002040).iconSet(FLINT)
                 .flags(NO_SMASHING, MORTAR_GRINDABLE, DECOMPOSITION_BY_CENTRIFUGING)
-                .toolStats(6, 4, 80)
+                .toolStats(6, 4, 80, 10)
                 .build();
 
         Air = new Material.Builder(2050, "air")

--- a/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/UnknownCompositionMaterials.java
@@ -316,7 +316,7 @@ public class UnknownCompositionMaterials {
                 .gem(3).ore()
                 .color(0x64C8FF).iconSet(EMERALD)
                 .flags(STD_GEM, NO_SMASHING, NO_SMELTING)
-                .toolStats(12.0f, 3.0f, 128)
+                .toolStats(12.0f, 3.0f, 128, 15)
                 .addDefaultEnchant(Enchantments.FORTUNE, 2)
                 .build();
 

--- a/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/ToolProperty.java
@@ -36,6 +36,14 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     public final int toolDurability;
 
     /**
+     * Enchantability of tools made from this Material.
+     * <p>
+     * Default:
+     */
+    //@ZenProperty
+    public final int toolEnchantability;
+
+    /**
      * Enchantment to be applied to tools made from this Material.
      * <p>
      * Default: none.
@@ -43,17 +51,18 @@ public class ToolProperty implements IMaterialProperty<ToolProperty> {
     //@ZenProperty
     public final List<EnchantmentData> toolEnchantments = new ArrayList<>();
 
-    public ToolProperty(float toolSpeed, float toolAttackDamage, int toolDurability) {
+    public ToolProperty(float toolSpeed, float toolAttackDamage, int toolDurability, int toolEnchantability) {
         this.toolSpeed = toolSpeed;
         this.toolAttackDamage = toolAttackDamage;
         this.toolDurability = toolDurability;
+        this.toolEnchantability = toolEnchantability;
     }
 
     /**
      * Default values constructor.
      */
     public ToolProperty() {
-        this(1.0f, 1.0f, 100);
+        this(1.0f, 1.0f, 100, 10);
     }
 
     @Override

--- a/src/main/java/gregtech/common/items/behaviors/NanoSaberBehavior.java
+++ b/src/main/java/gregtech/common/items/behaviors/NanoSaberBehavior.java
@@ -5,8 +5,6 @@ import com.google.common.collect.Multimap;
 import gregtech.api.GTValues;
 import gregtech.api.items.metaitem.MetaItem.MetaValueItem;
 import gregtech.api.items.metaitem.stats.IEnchantabilityHelper;
-import gregtech.api.items.toolitem.ToolMetaItem;
-import gregtech.api.unification.material.Materials;
 import gregtech.common.ConfigHolder;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.entity.SharedMonsterAttributes;
@@ -57,7 +55,7 @@ public class NanoSaberBehavior extends ToggleEnergyConsumerBehavior implements I
 
     @Override
     public int getItemEnchantability(ItemStack stack) {
-        return ToolMetaItem.getMaterialEnchantability(Materials.Platinum);
+        return 33;
     }
 
     @Override


### PR DESCRIPTION
- Nano Saber gets 33 enchantability, it inherited platinum's enchantability before but right now platinum doesn't have the tool property
- Deprecated old static helper method to get a material enchantability (delete outright?)