### PR TITLE
Allow specifying the amount of fluid for chemical bath processing

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -696,6 +696,12 @@ public class Material implements Comparable<Material> {
             return this;
         }
 
+        public Builder washedIn(Material m, int washedAmount) {
+            properties.ensureSet(PropertyKey.ORE);
+            properties.getProperty(PropertyKey.ORE).setWashedIn(m, washedAmount);
+            return this;
+        }
+
         public Builder separatedInto(Material... m) {
             properties.ensureSet(PropertyKey.ORE);
             properties.getProperty(PropertyKey.ORE).setSeparatedInto(m);

--- a/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
+++ b/src/main/java/gregtech/api/unification/material/properties/OreProperty.java
@@ -1,6 +1,7 @@
 package gregtech.api.unification.material.properties;
 
 import gregtech.api.unification.material.Material;
+import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -54,6 +55,14 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
     private Material washedIn;
 
     /**
+     * The amount of Material that the ore should be washed in
+     * in the Chemical Bath.
+     * <p>
+     * Default 100 mb
+     */
+    private int washedAmount = 100;
+
+    /**
      * During Electromagnetic Separation, this Ore will be separated
      * into this Material and the Material specified by this field.
      * Limit 2 Materials
@@ -105,9 +114,14 @@ public class OreProperty implements IMaterialProperty<OreProperty> {
         this.washedIn = m;
     }
 
+    public void setWashedIn(@Nullable Material m, int washedAmount) {
+        this.washedIn = m;
+        this.washedAmount = washedAmount;
+    }
+
     @Nullable
-    public Material getWashedIn() {
-        return this.washedIn;
+    public Pair<Material, Integer> getWashedIn() {
+        return Pair.of(this.washedIn, this.washedAmount);
     }
 
     public void setSeparatedInto(Material... materials) {

--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -14,6 +14,7 @@ import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.List;
 
@@ -168,9 +169,10 @@ public class OreRecipeHandler {
 
         if (property.getWashedIn() != null) {
             Material washingByproduct = GTUtility.selectItemInList(3, material, property.getOreByProducts(), Material.class);
+            Pair<Material, Integer> washedInTuple = property.getWashedIn();
             RecipeMaps.CHEMICAL_BATH_RECIPES.recipeBuilder()
                     .input(crushedPrefix, material)
-                    .fluidInputs(property.getWashedIn().getFluid(property.getWashedIn() == Materials.SodiumPersulfate ? 100 : 1000))
+                    .fluidInputs(washedInTuple.getKey().getFluid(washedInTuple.getRight()))
                     .outputs(crushedPurifiedOre)
                     .chancedOutput(OreDictUnifier.get(OrePrefix.dust, washingByproduct, property.getByProductMultiplier()), 7000, 580)
                     .chancedOutput(OreDictUnifier.get(OrePrefix.dust, Materials.Stone), 4000, 650)


### PR DESCRIPTION
**What:**
Adds an additional builder call for `washedIn` allowing for specification of the amount of fluid that processing an ore in the chemical bath will take. This will default to a value of 100mb

**How solved:**
Added an additional method call, and changed the return value.

**Outcome:**
Allow for setting the amount of fluid that an ore ore will be washed in in the Chemical Bath