### PR TITLE
Fix for null materials being entered into the washedIn pair

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -167,12 +167,12 @@ public class OreRecipeHandler {
                         OreDictUnifier.get(OrePrefix.dust, Materials.Stone))
                 .buildAndRegister();
 
-        if (property.getWashedIn() != null) {
+        if (property.getWashedIn().getKey() != null) {
             Material washingByproduct = GTUtility.selectItemInList(3, material, property.getOreByProducts(), Material.class);
             Pair<Material, Integer> washedInTuple = property.getWashedIn();
             RecipeMaps.CHEMICAL_BATH_RECIPES.recipeBuilder()
                     .input(crushedPrefix, material)
-                    .fluidInputs(washedInTuple.getKey().getFluid(washedInTuple.getRight()))
+                    .fluidInputs(washedInTuple.getKey().getFluid(washedInTuple.getValue()))
                     .outputs(crushedPurifiedOre)
                     .chancedOutput(OreDictUnifier.get(OrePrefix.dust, washingByproduct, property.getByProductMultiplier()), 7000, 580)
                     .chancedOutput(OreDictUnifier.get(OrePrefix.dust, Materials.Stone), 4000, 650)


### PR DESCRIPTION
**What:**
Fix for the recent chem bath PR. Since the washedIn material is `nullable`, there could sometimes be null materials in the Pair, which would crash.

**How solved:**
Check that the material is not null before attempting to create a recipe

**Outcome:**
Fix for null material crash for chem bath recipes.