### PR TITLE
Fix Primitive and Steam Multis Double Updating Workables

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapPrimitiveMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapPrimitiveMultiblockController.java
@@ -1,6 +1,7 @@
 package gregtech.api.metatileentity.multiblock;
 
 import gregtech.api.capability.impl.*;
+import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.recipes.RecipeMap;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.fluids.FluidTank;
@@ -49,14 +50,7 @@ public abstract class RecipeMapPrimitiveMultiblockController extends MultiblockW
     }
 
     @Override
-    public void update() {
-        if (!getWorld().isRemote) {
-            if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
-                checkStructurePattern();
-            }
-            if (isStructureFormed()) {
-                updateFormedValid();
-            }
-        }
+    protected boolean shouldUpdate(MTETrait trait) {
+        return !(trait instanceof PrimitiveRecipeLogic);
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapPrimitiveMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapPrimitiveMultiblockController.java
@@ -47,4 +47,16 @@ public abstract class RecipeMapPrimitiveMultiblockController extends MultiblockW
         super.invalidateStructure();
         recipeMapWorkable.invalidate();
     }
+
+    @Override
+    public void update() {
+        if (!getWorld().isRemote) {
+            if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
+                checkStructurePattern();
+            }
+            if (isStructureFormed()) {
+                updateFormedValid();
+            }
+        }
+    }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
@@ -4,9 +4,6 @@ import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.ItemHandlerList;
 import gregtech.api.capability.impl.SteamMultiblockRecipeLogic;
-import gregtech.api.metatileentity.multiblock.IMultiblockPart;
-import gregtech.api.metatileentity.multiblock.MultiblockAbility;
-import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.multiblock.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
@@ -126,5 +123,17 @@ public abstract class RecipeMapSteamMultiblockController extends MultiblockWithD
                 .stream().map(it -> (IItemHandler) it).mapToInt(IItemHandler::getSlots).sum();
         return itemInputsCount >= recipeMap.getMinInputs() &&
                 abilities.containsKey(MultiblockAbility.STEAM);
+    }
+
+    @Override
+    public void update() {
+        if (!getWorld().isRemote) {
+            if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
+                checkStructurePattern();
+            }
+            if (isStructureFormed()) {
+                updateFormedValid();
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapSteamMultiblockController.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.ItemHandlerList;
 import gregtech.api.capability.impl.SteamMultiblockRecipeLogic;
+import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.multiblock.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
@@ -126,14 +127,7 @@ public abstract class RecipeMapSteamMultiblockController extends MultiblockWithD
     }
 
     @Override
-    public void update() {
-        if (!getWorld().isRemote) {
-            if (getOffsetTimer() % 20 == 0 || isFirstTick()) {
-                checkStructurePattern();
-            }
-            if (isStructureFormed()) {
-                updateFormedValid();
-            }
-        }
+    protected boolean shouldUpdate(MTETrait trait) {
+        return !(trait instanceof SteamMultiblockRecipeLogic);
     }
 }


### PR DESCRIPTION
Prevents Primitive and Steam multiblocks from updating their workables twice every tick.