### PR TITLE
Fix separate multi dimensions in worldgen jsons

### DIFF
--- a/CHANGELOG-GTCEU.md
+++ b/CHANGELOG-GTCEU.md
@@ -217,6 +217,7 @@
 - Fix Solar covers not properly outputting power to GT cables
 - Fix Crowbar action on Powered Rails throwing errors in the log
 - Fix Fluid Regulator "Keep Exact" mode not working
+- Fix worldgen JSONs only using the first dimension listed in `dimension_filter`
 
 ### CraftTweaker
 - Materials can now automatically generate IDs


### PR DESCRIPTION
**What:**
This is identical to [this pr](https://github.com/GregTechCE/GregTech/pull/1713) as it also affects CEu.
Fixes declaring multiple dimensions separately in a worldgen json file.

**How solved:**
Use only 1 return to prevent skipping over all other dimensions.

**Outcome:**
Fixes multiple dimensions separately specified not working for worldgen beyond the first.
One can also declare dimensions in different ways consecutively:
`"dimension_filter": ["dimension_id:0","dimension_id:1","dimension_id:-1"],` works
`"dimension_filter": ["dimension_id:-1","name:the_end","name:*(overworld)"],` also works
`"dimension_filter": ["dimension_id:0:1","dimension_id:-1"],` also works

**Additional info:**
There may be a better way to do this. I found this to be the fastest way to fix this.

**Possible compatibility issue:**
None so far after testing in different ways.