### PR TITLE
Render chanced output chance text overlay in JEI

### DIFF
--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -109,6 +109,10 @@ public class GTRecipeWrapper implements IRecipeWrapper {
         }
     }
 
+    public Int2ObjectMap<ChanceEntry> getChanceOutputMap() {
+        return chanceOutput;
+    }
+
     private int getPropertyListHeight() {
         return (recipe.getPropertyCount() + 3) * LINE_HEIGHT - 3;
     }

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -105,9 +105,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                             slotWidget.getPosition().y);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
-                    ChanceEntry chanceEntry = chanceOutputMap.get(importItems.getSlots() + handle.getSlotIndex());
                     itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,
-                            new ItemStackChanceRenderer(chanceEntry),
+                            new ItemStackChanceRenderer(chanceOutputMap.get(importItems.getSlots() + handle.getSlotIndex())),
                             slotWidget.getPosition().x + 1,
                             slotWidget.getPosition().y + 1,
                             slotWidget.getSize().width - 2,

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -9,8 +9,11 @@ import gregtech.api.gui.Widget;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
+import gregtech.api.recipes.Recipe.ChanceEntry;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.integration.jei.utils.render.FluidStackTextRenderer;
+import gregtech.integration.jei.utils.render.ItemStackChanceRenderer;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
 import mezz.jei.api.gui.IGuiFluidStackGroup;
@@ -86,6 +89,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     public void setRecipe(IRecipeLayout recipeLayout, @Nonnull GTRecipeWrapper recipeWrapper, @Nonnull IIngredients ingredients) {
         IGuiItemStackGroup itemStackGroup = recipeLayout.getItemStacks();
         IGuiFluidStackGroup fluidStackGroup = recipeLayout.getFluidStacks();
+        Int2ObjectMap<ChanceEntry> chanceOutputMap = recipeWrapper.getChanceOutputMap();
         for (Widget uiWidget : modularUI.guiWidgets.values()) {
 
             if (uiWidget instanceof SlotWidget) {
@@ -101,9 +105,13 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                             slotWidget.getPosition().y);
                 } else if (handle.getItemHandler() == exportItems) {
                     //this is output item stack slot widget, so add it to item group
+                    ChanceEntry chanceEntry = chanceOutputMap.get(importItems.getSlots() + handle.getSlotIndex());
                     itemStackGroup.init(importItems.getSlots() + handle.getSlotIndex(), false,
-                            slotWidget.getPosition().x,
-                            slotWidget.getPosition().y);
+                            new ItemStackChanceRenderer(chanceEntry),
+                            slotWidget.getPosition().x + 1,
+                            slotWidget.getPosition().y + 1,
+                            slotWidget.getSize().width - 2,
+                            slotWidget.getSize().height - 2, 0, 0);
                 }
             } else if (uiWidget instanceof TankWidget) {
                 TankWidget tankWidget = (TankWidget) uiWidget;

--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackChanceRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackChanceRenderer.java
@@ -1,0 +1,44 @@
+package gregtech.integration.jei.utils.render;
+
+import gregtech.api.gui.resources.RenderUtil;
+import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.Recipe.ChanceEntry;
+import gregtech.api.util.TextFormattingUtil;
+import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.item.ItemStack;
+
+import javax.annotation.Nullable;
+
+public class ItemStackChanceRenderer extends ItemStackRenderer {
+    private ChanceEntry chance;
+
+    public ItemStackChanceRenderer(ChanceEntry chance) {
+        this.chance = chance;
+    }
+
+    @Override
+    public void render(Minecraft minecraft, int xPosition, int yPosition, @Nullable ItemStack ingredient) {
+        super.render(minecraft, xPosition, yPosition, ingredient);
+
+        if (this.chance != null) {
+            GlStateManager.disableBlend();
+            GlStateManager.pushMatrix();
+            GlStateManager.scale(0.5, 0.5, 1);
+            // z hackery to render the text above the item
+            GlStateManager.translate(0, 0, 151);
+
+            String s = (this.chance.getChance() / 100) + "%";
+            if (this.chance.getBoostPerTier() > 0)
+                s += "+";
+
+            FontRenderer fontRenderer = Minecraft.getMinecraft().fontRenderer;
+            fontRenderer.drawStringWithShadow(s, (xPosition + 6) * 2 - fontRenderer.getStringWidth(s) + 19, (yPosition + 1) * 2, 0xFFFF00);
+
+            GlStateManager.popMatrix();
+            GlStateManager.enableBlend();
+        }
+    }
+}

--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackChanceRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackChanceRenderer.java
@@ -1,9 +1,6 @@
 package gregtech.integration.jei.utils.render;
 
-import gregtech.api.gui.resources.RenderUtil;
-import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
-import gregtech.api.util.TextFormattingUtil;
 import mezz.jei.plugins.vanilla.ingredients.item.ItemStackRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
@@ -13,7 +10,7 @@ import net.minecraft.item.ItemStack;
 import javax.annotation.Nullable;
 
 public class ItemStackChanceRenderer extends ItemStackRenderer {
-    private ChanceEntry chance;
+    private final ChanceEntry chance;
 
     public ItemStackChanceRenderer(ChanceEntry chance) {
         this.chance = chance;


### PR DESCRIPTION
**What:**
Adds overlay text to chanced outputs in JEI showing what their chances are
Percentage is truncated to whole percentage points
Tier-based chance boosts are denoted by a `+` after the `%`

**How solved:**
Another custom JEI renderer

**Additional info:**
![image](https://user-images.githubusercontent.com/66188216/131263558-691b596a-93b1-43bc-85dc-dd1b90035c55.png)
![image](https://user-images.githubusercontent.com/66188216/131263563-5ae0c405-db76-4463-be55-a7f1ab0f570e.png)