### PR TITLE
Quick fix for muffler issuing particles when paused

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -101,8 +101,9 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
             this.recipeMapWorkable.updateWorkable();
     }
 
+    @Override
     public boolean isActive() {
-        return isStructureFormed() && recipeMapWorkable.isActive();
+        return isStructureFormed() && recipeMapWorkable.isActive() && recipeMapWorkable.isWorkingEnabled();
     }
 
     private void initializeAbilities() {


### PR DESCRIPTION
**What:**
Adds a check for if the multiblock is paused in the `isActive` override



**Outcome:**
Prevents mufflers from issuing particles when the multiblock is paused.