### PR TITLE
Implement Distinct Buses

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -208,7 +208,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         this.invalidInputsForRecipes = (currentRecipe == null);
 
         // proceed if we have a usable recipe.
-        if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
+        if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory))
             setupRecipe(currentRecipe);
         // Inputs have been inspected.
         metaTileEntity.getNotifiedItemInputList().clear();
@@ -236,10 +236,21 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
                         ItemStack.areItemStackTagsEqual(stackA, stackB));
     }
 
-    protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
+    /**
+     * Determines if the provided recipe is possible to run from the provided inventory, or if there is anything preventing
+     * the Recipe from being completed.
+     *
+     * Will consume the inputs of the Recipe if it is possible to run.
+     *
+     * @param recipe - The Recipe that will be consumed from the inputs and ran in the machine
+     * @param importInventory - The inventory that the recipe should be consumed from.
+     *                        Used mainly for Distinct bus implementation for multiblocks to specify
+     *                        a specific bus
+     * @return - true if the recipe is successful, false if the recipe is not successful
+     */
+    protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
         int[] resultOverclock = calculateOverclock(recipe.getEUt(), recipe.getDuration());
         int totalEUt = resultOverclock[0] * resultOverclock[1];
-        IItemHandlerModifiable importInventory = getInputInventory();
         IItemHandlerModifiable exportInventory = getOutputInventory();
         IMultipleTankHandler importFluids = getInputTank();
         IMultipleTankHandler exportFluids = getOutputTank();

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -49,6 +49,10 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         setActive(false); // this marks dirty for us
     }
 
+    public void onDistinctChanged() {
+        this.lastRecipeIndex = 0;
+    }
+
     public IEnergyContainer getEnergyContainer() {
         RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
         return controller.getEnergyContainer();

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -2,12 +2,19 @@ package gregtech.api.capability.impl;
 
 import gregtech.api.capability.IEnergyContainer;
 import gregtech.api.capability.IMultipleTankHandler;
+import gregtech.api.metatileentity.multiblock.MultiblockAbility;
 import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
+import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
+import java.util.List;
+
 public class MultiblockRecipeLogic extends AbstractRecipeLogic {
+
+    // Used for distinct mode
+    protected int lastRecipeIndex = 0;
 
 
     public MultiblockRecipeLogic(RecipeMapMultiblockController tileEntity) {
@@ -36,6 +43,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         recipeEUt = 0;
         fluidOutputs = null;
         itemOutputs = null;
+        lastRecipeIndex = 0;
         setActive(false); // this marks dirty for us
     }
 
@@ -48,6 +56,12 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     protected IItemHandlerModifiable getInputInventory() {
         RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
         return controller.getInputInventory();
+    }
+
+    // Used for distinct bus recipe checking
+    protected List<IItemHandlerModifiable> getInputBuses() {
+        RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
+        return controller.getAbilities(MultiblockAbility.IMPORT_ITEMS);
     }
 
     @Override
@@ -71,11 +85,74 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     @Override
     protected void trySearchNewRecipe() {
         // do not run recipes when there are more than 5 maintenance problems
+        // Maintenance can apply to all multiblocks, so cast to a base multiblock class
         MultiblockWithDisplayBase controller = (MultiblockWithDisplayBase) metaTileEntity;
-        if (controller.hasMaintenanceMechanics() && controller.getNumMaintenanceProblems() > 5)
+        if (controller.hasMaintenanceMechanics() && controller.getNumMaintenanceProblems() > 5) {
             return;
+        }
+
+        // Distinct buses only apply to some of the multiblocks, so check the controller against a lower class
+        if(controller instanceof RecipeMapMultiblockController) {
+            RecipeMapMultiblockController distinctController = (RecipeMapMultiblockController) controller;
+
+            if(distinctController.canBeDistinct() && distinctController.isDistinct()) {
+                trySearchNewRecipeDistinct();
+                return;
+            }
+        }
 
         super.trySearchNewRecipe();
+    }
+
+    protected void trySearchNewRecipeDistinct() {
+        long maxVoltage = getMaxVoltage();
+        Recipe currentRecipe = null;
+        List<IItemHandlerModifiable> importInventory = getInputBuses();
+        IMultipleTankHandler importFluids = getInputTank();
+
+        // Our caching implementation
+        // This guarantees that if we get a recipe cache hit, our efficiency is no different from other machines
+        if (previousRecipe != null && previousRecipe.matches(false, importInventory.get(lastRecipeIndex), importFluids)) {
+            currentRecipe = previousRecipe;
+            // TODO, is setting the invalidInputs here needed?
+            invalidInputsForRecipes = false;
+            // If a valid recipe is found, immediately attempt to return it to prevent inventory scanning
+            if (setupAndConsumeRecipeInputs(currentRecipe, importInventory.get(lastRecipeIndex))) {
+                setupRecipe(currentRecipe);
+                metaTileEntity.getNotifiedItemInputList().clear();
+                metaTileEntity.getNotifiedFluidInputList().clear();
+                //TODO, should we set the previous recipe to the current recipe here, or would that cause some issues with caching once parallel is introduced?
+                return;
+            }
+        }
+
+        // On a cache miss, our efficiency is much worse, as it will check
+        // each bus individually instead of the combined inventory all at once.
+        for (int i = 0; i < importInventory.size(); i++) {
+            IItemHandlerModifiable bus = importInventory.get(i);
+            boolean inputsChanged = hasNotifiedInputs();
+            // If the inputs have changed since the last recipe calculation, find a new recipe based on the new inputs
+            if (inputsChanged) {
+                currentRecipe = findRecipe(maxVoltage, bus, importFluids, MatchingMode.DEFAULT);
+                // Cache the current recipe, if one is found
+                if (currentRecipe != null) {
+                    this.previousRecipe = currentRecipe;
+                }
+            }
+
+            invalidInputsForRecipes = (currentRecipe == null);
+
+            if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory.get(i))) {
+                lastRecipeIndex = i;
+                setupRecipe(currentRecipe);
+                metaTileEntity.getNotifiedItemInputList().clear();
+                metaTileEntity.getNotifiedFluidInputList().clear();
+                break;
+            }
+        }
+
+        // TODO, if we don't find anything, should we reset the notified inputs?
+
     }
 
     @Override
@@ -91,10 +168,10 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
+    protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
         RecipeMapMultiblockController controller = (RecipeMapMultiblockController) metaTileEntity;
         if (controller.checkRecipe(recipe, false) &&
-                super.setupAndConsumeRecipeInputs(recipe)) {
+                super.setupAndConsumeRecipeInputs(recipe, importInventory)) {
             controller.checkRecipe(recipe, true);
             return true;
         } else return false;

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -114,14 +114,14 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         // This guarantees that if we get a recipe cache hit, our efficiency is no different from other machines
         if (previousRecipe != null && previousRecipe.matches(false, importInventory.get(lastRecipeIndex), importFluids)) {
             currentRecipe = previousRecipe;
-            // TODO, is setting the invalidInputs here needed?
-            invalidInputsForRecipes = false;
             // If a valid recipe is found, immediately attempt to return it to prevent inventory scanning
             if (setupAndConsumeRecipeInputs(currentRecipe, importInventory.get(lastRecipeIndex))) {
                 setupRecipe(currentRecipe);
-                metaTileEntity.getNotifiedItemInputList().clear();
-                metaTileEntity.getNotifiedFluidInputList().clear();
-                //TODO, should we set the previous recipe to the current recipe here, or would that cause some issues with caching once parallel is introduced?
+                metaTileEntity.getNotifiedItemInputList().remove(lastRecipeIndex);
+                metaTileEntity.getNotifiedFluidInputList().remove(lastRecipeIndex);
+
+                // No need to cache the previous recipe here, as it is not null and matched by the current recipe,
+                // so it will always be the same
                 return;
             }
         }
@@ -145,14 +145,15 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
             if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory.get(i))) {
                 lastRecipeIndex = i;
                 setupRecipe(currentRecipe);
-                metaTileEntity.getNotifiedItemInputList().clear();
-                metaTileEntity.getNotifiedFluidInputList().clear();
+                metaTileEntity.getNotifiedItemInputList().remove(i);
+                metaTileEntity.getNotifiedFluidInputList().remove(i);
                 break;
             }
         }
 
-        // TODO, if we don't find anything, should we reset the notified inputs?
-
+        //If no matching recipes are found, clear the notified inputs so we know when new items are given
+        metaTileEntity.getNotifiedItemInputList().clear();
+        metaTileEntity.getNotifiedFluidInputList().clear();
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
+++ b/src/main/java/gregtech/api/capability/impl/RecipeLogicSteam.java
@@ -21,6 +21,7 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.WorldServer;
 import net.minecraftforge.fluids.IFluidTank;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class RecipeLogicSteam extends AbstractRecipeLogic {
 
@@ -155,8 +156,8 @@ public class RecipeLogicSteam extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
-        return !this.needsVenting && super.setupAndConsumeRecipeInputs(recipe);
+    protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
+        return !this.needsVenting && super.setupAndConsumeRecipeInputs(recipe, importInventory);
     }
 
     @Override

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiWorkable.java
@@ -53,7 +53,7 @@ public class SteamMultiWorkable extends SteamMultiblockRecipeLogic {
             // replace old recipe with new one
             this.previousRecipe = currentRecipe;
         // proceed if we have a usable recipe.
-        if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
+        if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory))
             setupRecipe(currentRecipe);
         // Inputs have been inspected.
         metaTileEntity.getNotifiedItemInputList().clear();

--- a/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/SteamMultiblockRecipeLogic.java
@@ -107,10 +107,10 @@ public class SteamMultiblockRecipeLogic extends AbstractRecipeLogic {
     }
 
     @Override
-    protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
+    protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
         RecipeMapSteamMultiblockController controller = (RecipeMapSteamMultiblockController) metaTileEntity;
         if (controller.checkRecipe(recipe, false) &&
-                super.setupAndConsumeRecipeInputs(recipe)) {
+                super.setupAndConsumeRecipeInputs(recipe, importInventory)) {
             controller.checkRecipe(recipe, true);
             return true;
         } else return false;

--- a/src/main/java/gregtech/api/gui/widgets/AdvancedTextWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/AdvancedTextWidget.java
@@ -52,7 +52,9 @@ public class AdvancedTextWidget extends Widget {
     public static ITextComponent withButton(ITextComponent textComponent, String componentData) {
         Style style = textComponent.getStyle();
         style.setClickEvent(new ClickEvent(Action.OPEN_URL, "@!" + componentData));
-        style.setColor(TextFormatting.YELLOW);
+        if(style.getColor() == null) {
+            style.setColor(TextFormatting.YELLOW);
+        }
         return textComponent;
     }
 

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -46,7 +46,6 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     protected IMultipleTankHandler outputFluidInventory;
     protected IEnergyContainer energyContainer;
 
-    private boolean canDistinct = true;
     private boolean isDistinct = false;
 
     public RecipeMapMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap) {
@@ -224,7 +223,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     public boolean canBeDistinct() {
-        return canDistinct;
+        return true;
     }
 
     public boolean isDistinct() {

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -173,13 +173,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     @Override
     protected void handleDisplayClick(String componentData, Widget.ClickData clickData) {
         super.handleDisplayClick(componentData, clickData);
-        isDistinct = !isDistinct;
-        //mark busses as changed on distinct toggle
-        if (isDistinct) {
-            this.notifiedItemInputList.addAll(this.getAbilities(MultiblockAbility.IMPORT_ITEMS));
-        } else {
-            this.notifiedItemInputList.add(this.inputInventory);
-        }
+        toggleDistinct();
     }
 
     @Override
@@ -234,5 +228,16 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
 
     public boolean isDistinct() {
         return isDistinct;
+    }
+
+    protected void toggleDistinct() {
+        isDistinct = !isDistinct;
+        recipeMapWorkable.onDistinctChanged();
+        //mark buses as changed on distinct toggle
+        if (isDistinct) {
+            this.notifiedItemInputList.addAll(this.getAbilities(MultiblockAbility.IMPORT_ITEMS));
+        } else {
+            this.notifiedItemInputList.add(this.inputInventory);
+        }
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -12,11 +12,15 @@ import gregtech.api.capability.impl.EnergyContainerList;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.ItemHandlerList;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
+import gregtech.api.gui.Widget;
+import gregtech.api.gui.widgets.AdvancedTextWidget;
 import gregtech.api.multiblock.PatternMatchContext;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.util.GTUtility;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.Style;
@@ -41,6 +45,9 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     protected IMultipleTankHandler inputFluidInventory;
     protected IMultipleTankHandler outputFluidInventory;
     protected IEnergyContainer energyContainer;
+
+    private boolean canDistinct = true;
+    private boolean isDistinct = false;
 
     public RecipeMapMultiblockController(ResourceLocation metaTileEntityId, RecipeMap<?> recipeMap) {
         super(metaTileEntityId);
@@ -136,6 +143,17 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
                 textList.add(new TextComponentTranslation("gregtech.multiblock.max_energy_per_tick", maxVoltage, voltageName));
             }
 
+            if(canBeDistinct()) {
+                ITextComponent buttonText = new TextComponentTranslation("gregtech.multiblock.universal.distinct");
+                buttonText.appendText(" ");
+                ITextComponent button = AdvancedTextWidget.withButton(isDistinct() ?
+                        new TextComponentTranslation("gregtech.multiblock.universal.distinct.yes").setStyle(new Style().setColor(TextFormatting.GREEN)) :
+                        new TextComponentTranslation("gregtech.multiblock.universal.distinct.no").setStyle(new Style().setColor(TextFormatting.RED)), "distinct");
+                AdvancedTextWidget.withHoverTextTranslate(button, "gregtech.multiblock.universal.distinct.info");
+                buttonText.appendSibling(button);
+                textList.add(buttonText);
+            }
+
             if (!recipeMapWorkable.isWorkingEnabled()) {
                 textList.add(new TextComponentTranslation("gregtech.multiblock.work_paused"));
 
@@ -154,18 +172,21 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     @Override
+    protected void handleDisplayClick(String componentData, Widget.ClickData clickData) {
+        super.handleDisplayClick(componentData, clickData);
+        isDistinct = !isDistinct;
+    }
+
+    @Override
     protected boolean checkStructureComponents(List<IMultiblockPart> parts, Map<MultiblockAbility<Object>, List<Object>> abilities) {
         boolean canForm = super.checkStructureComponents(parts, abilities);
         if (!canForm)
             return false;
 
         //basically check minimal requirements for inputs count
-        //noinspection SuspiciousMethodCalls
         int itemInputsCount = abilities.getOrDefault(MultiblockAbility.IMPORT_ITEMS, Collections.emptyList())
                 .stream().map(it -> (IItemHandler) it).mapToInt(IItemHandler::getSlots).sum();
-        //noinspection SuspiciousMethodCalls
         int fluidInputsCount = abilities.getOrDefault(MultiblockAbility.IMPORT_FLUIDS, Collections.emptyList()).size();
-        //noinspection SuspiciousMethodCalls
         return itemInputsCount >= recipeMap.getMinInputs() &&
                 fluidInputsCount >= recipeMap.getMinFluidInputs() &&
                 abilities.containsKey(MultiblockAbility.INPUT_ENERGY);
@@ -175,5 +196,38 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     public void renderMetaTileEntity(CCRenderState renderState, Matrix4 translation, IVertexOperation[] pipeline) {
         super.renderMetaTileEntity(renderState, translation, pipeline);
         this.getFrontOverlay().render(renderState, translation, pipeline, getFrontFacing(), recipeMapWorkable.isActive());
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound data) {
+        super.writeToNBT(data);
+        data.setBoolean("isDistinct", isDistinct);
+        return data;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound data) {
+        super.readFromNBT(data);
+        isDistinct = data.getBoolean("isDistinct");
+    }
+
+    @Override
+    public void writeInitialSyncData(PacketBuffer buf) {
+        super.writeInitialSyncData(buf);
+        buf.writeBoolean(isDistinct);
+    }
+
+    @Override
+    public void receiveInitialSyncData(PacketBuffer buf) {
+        super.receiveInitialSyncData(buf);
+        isDistinct = buf.readBoolean();
+    }
+
+    public boolean canBeDistinct() {
+        return canDistinct;
+    }
+
+    public boolean isDistinct() {
+        return isDistinct;
     }
 }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -174,6 +174,12 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     protected void handleDisplayClick(String componentData, Widget.ClickData clickData) {
         super.handleDisplayClick(componentData, clickData);
         isDistinct = !isDistinct;
+        //mark busses as changed on distinct toggle
+        if (isDistinct) {
+            this.notifiedItemInputList.addAll(this.getAbilities(MultiblockAbility.IMPORT_ITEMS));
+        } else {
+            this.notifiedItemInputList.add(this.inputInventory);
+        }
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/RecipeMapMultiblockController.java
@@ -223,7 +223,7 @@ public abstract class RecipeMapMultiblockController extends MultiblockWithDispla
     }
 
     public boolean canBeDistinct() {
-        return true;
+        return false;
     }
 
     public boolean isDistinct() {

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityGasCollector.java
@@ -87,7 +87,7 @@ public class MetaTileEntityGasCollector extends SimpleMachineMetaTileEntity {
             this.invalidInputsForRecipes = (currentRecipe == null);
 
             // proceed if we have a usable recipe.
-            if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
+            if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory))
                 setupRecipe(currentRecipe);
             // Inputs have been inspected.
             metaTileEntity.getNotifiedItemInputList().clear();

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -148,6 +148,11 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
     }
 
     @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
+
+    @Override
     public boolean hasMufflerMechanics() {
         return true;
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -200,6 +200,11 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController {
     }
 
     @Override
+    public boolean canBeDistinct() {
+        return false;
+    }
+
+    @Override
     public boolean hasMaintenanceMechanics() {
         return false;
     }
@@ -231,12 +236,12 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected boolean setupAndConsumeRecipeInputs(Recipe recipe) {
+        protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
             long heatDiff = recipe.getProperty(FusionEUToStartProperty.getInstance(), 0L) - heat;
             if (heatDiff <= 0) {
-                return super.setupAndConsumeRecipeInputs(recipe);
+                return super.setupAndConsumeRecipeInputs(recipe, importInventory);
             }
-            if (energyContainer.getEnergyStored() < heatDiff || !super.setupAndConsumeRecipeInputs(recipe)) {
+            if (energyContainer.getEnergyStored() < heatDiff || !super.setupAndConsumeRecipeInputs(recipe, importInventory)) {
                 return false;
             }
             energyContainer.removeEnergy(heatDiff);

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityFusionReactor.java
@@ -200,11 +200,6 @@ public class MetaTileEntityFusionReactor extends RecipeMapMultiblockController {
     }
 
     @Override
-    public boolean canBeDistinct() {
-        return false;
-    }
-
-    @Override
     public boolean hasMaintenanceMechanics() {
         return false;
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityImplosionCompressor.java
@@ -69,4 +69,9 @@ public class MetaTileEntityImplosionCompressor extends RecipeMapMultiblockContro
     public boolean hasMufflerMechanics() {
         return true;
     }
+
+    @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
@@ -86,8 +86,4 @@ public class MetaTileEntityLargeChemicalReactor extends RecipeMapMultiblockContr
         return Textures.LARGE_CHEMICAL_REACTOR_OVERLAY;
     }
 
-    @Override
-    public boolean canBeDistinct() {
-        return false;
-    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityLargeChemicalReactor.java
@@ -85,4 +85,9 @@ public class MetaTileEntityLargeChemicalReactor extends RecipeMapMultiblockContr
     protected OrientedOverlayRenderer getFrontOverlay() {
         return Textures.LARGE_CHEMICAL_REACTOR_OVERLAY;
     }
+
+    @Override
+    public boolean canBeDistinct() {
+        return false;
+    }
 }

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
@@ -147,7 +147,7 @@ public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
                 // replace old recipe with new one
                 this.previousRecipe = currentRecipe;
             // proceed if we have a usable recipe.
-            if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe))
+            if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory))
                 setupRecipe(currentRecipe);
             // Inputs have been inspected.
             metaTileEntity.getNotifiedItemInputList().clear();

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityPyrolyseOven.java
@@ -70,4 +70,9 @@ public class MetaTileEntityPyrolyseOven extends RecipeMapMultiblockController {
     public boolean hasMufflerMechanics() {
         return true;
     }
+
+    @Override
+    public boolean canBeDistinct() {
+        return true;
+    }
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3815,6 +3815,10 @@ gregtech.multiblock.universal.problem.wire_cutter=%s§7Wires burned out. (§aWir
 gregtech.multiblock.universal.problem.crowbar=%s§7That doesn't belong there. (§aCrowbar§7)
 gregtech.multiblock.universal.muffler_obstructed=Muffler Hatch is Obstructed!
 gregtech.multiblock.universal.muffler_obstructed.tooltip=Muffler Hatch must have a block of airspace in front of it.
+gregtech.multiblock.universal.distinct=Distinct Buses:
+gregtech.multiblock.universal.distinct.no=No
+gregtech.multiblock.universal.distinct.yes=Yes
+gregtech.multiblock.universal.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
 
 gregtech.multiblock.preview.tilt=Shift+LMB to tilt
 gregtech.multiblock.preview.zoom=Shift+RMB to zoom

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3818,7 +3818,7 @@ gregtech.multiblock.universal.muffler_obstructed.tooltip=Muffler Hatch must have
 gregtech.multiblock.universal.distinct=Distinct Buses:
 gregtech.multiblock.universal.distinct.no=No
 gregtech.multiblock.universal.distinct.yes=Yes
-gregtech.multiblock.universal.distinct.info=If enabled, each bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Extruder Shapes, Laser Lenses, etc..
+gregtech.multiblock.universal.distinct.info=If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.
 
 gregtech.multiblock.preview.tilt=Shift+LMB to tilt
 gregtech.multiblock.preview.zoom=Shift+RMB to zoom

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -11,10 +11,14 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
+import gregtech.api.unification.material.MaterialRegistry;
 import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.util.Position;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityFluidHatch;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityItemBus;
+import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMufflerHatch;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
 import net.minecraft.block.state.IBlockState;
@@ -29,6 +33,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertTrue;
@@ -39,6 +45,7 @@ public class MultiblockRecipeLogicTest {
     public static void init() {
         Bootstrap.register();
         Materials.register();
+        OrePrefix.runMaterialHandlers();
     }
 
     private static ResourceLocation gregtechId(String name) {
@@ -75,6 +82,11 @@ public class MultiblockRecipeLogicTest {
                         new MetaTileEntityElectricBlastFurnace(
                                 // super function calls the world, which equal null in test
                                 new ResourceLocation(GTValues.MODID, "electric_blast_furnace")) {
+                            @Override
+                            public boolean canBeDistinct() {
+                                return false;
+                            }
+
                             @Override
                             protected void reinitializeStructurePattern() {
 
@@ -227,6 +239,7 @@ public class MultiblockRecipeLogicTest {
         mbl.trySearchNewRecipe();
 
         // no recipe found
+        assertFalse(mbt.isDistinct());
         assertTrue(mbl.invalidInputsForRecipes);
         assertFalse(mbl.isActive);
         assertNull(mbl.previousRecipe);
@@ -240,6 +253,276 @@ public class MultiblockRecipeLogicTest {
         assertNotNull(mbl.previousRecipe);
         assertTrue(mbl.isActive);
         assertEquals(15, mbl.getInputInventory().getStackInSlot(0).getCount());
+        //assert the consumption of the inputs did not mark the arl to look for a new recipe
+        assertFalse(mbl.hasNotifiedInputs());
+
+        // Save a reference to the old recipe so we can make sure it's getting reused
+        Recipe prev = mbl.previousRecipe;
+
+        // Finish the recipe, the output should generate, and the next iteration should begin
+        mbl.updateWorkable();
+        assertEquals(prev, mbl.previousRecipe);
+        assertTrue(AbstractRecipeLogic.areItemStacksEqual(mbl.getOutputInventory().getStackInSlot(0),
+                new ItemStack(Blocks.STONE, 1)));
+        assertTrue(mbl.isActive);
+
+        // Complete the second iteration, but the machine stops because its output is now full
+        mbl.getOutputInventory().setStackInSlot(0, new ItemStack(Blocks.STONE, 63));
+        mbl.getOutputInventory().setStackInSlot(1, new ItemStack(Blocks.STONE, 64));
+        mbl.getOutputInventory().setStackInSlot(2, new ItemStack(Blocks.STONE, 64));
+        mbl.getOutputInventory().setStackInSlot(3, new ItemStack(Blocks.STONE, 64));
+        mbl.updateWorkable();
+        assertFalse(mbl.isActive);
+        assertTrue(mbl.isOutputsFull);
+
+        // Try to process again and get failed out because of full buffer.
+        mbl.updateWorkable();
+        assertFalse(mbl.isActive);
+        assertTrue(mbl.isOutputsFull);
+
+        // Some room is freed in the output bus, so we can continue now.
+        mbl.getOutputInventory().setStackInSlot(1, ItemStack.EMPTY);
+        assertTrue(mbl.hasNotifiedOutputs());
+        mbl.updateWorkable();
+        assertTrue(mbl.isActive);
+        assertFalse(mbl.isOutputsFull);
+        mbl.completeRecipe();
+        assertTrue(AbstractRecipeLogic.areItemStacksEqual(mbl.getOutputInventory().getStackInSlot(0),
+                new ItemStack(Blocks.STONE, 1)));
+    }
+
+    @Test
+    public void trySearchNewRecipeDistinct() {
+
+        World world = DummyWorld.INSTANCE;
+
+        // Create an empty recipe map to work with
+        RecipeMap<BlastRecipeBuilder> map = new RecipeMap<>("blast_furnace",
+                1,
+                3,
+                1,
+                2,
+                0,
+                1,
+                0,
+                1,
+                new BlastRecipeBuilder().EUt(32),
+                false);
+
+        RecipeMaps.BLAST_RECIPES.recipeBuilder()
+                .inputs(new ItemStack(Blocks.COBBLESTONE))
+                .outputs(new ItemStack(Blocks.STONE))
+                .EUt(1).duration(1)
+                .blastFurnaceTemp(1)
+                .buildAndRegister();
+
+        RecipeMapMultiblockController mbt =
+                GregTechAPI.registerMetaTileEntity(511,
+                        new MetaTileEntityElectricBlastFurnace(
+                                // super function calls the world, which equal null in test
+                                new ResourceLocation(GTValues.MODID, "electric_blast_furnace")) {
+
+                            @Override
+                            public boolean hasMufflerMechanics() {
+                                return false;
+                            }
+
+                            // ignore maintenance problems
+                            @Override
+                            public boolean hasMaintenanceMechanics() {
+                                return false;
+                            }
+
+
+                            @Override
+                            protected void reinitializeStructurePattern() {
+
+                            }
+
+                            // function checks for the temperature of the recipe against the coils
+                            @Override
+                            public boolean checkRecipe(Recipe recipe, boolean consumeIfSuccess) {
+                                return true;
+                            }
+                        });
+
+        //isValid() check in the dirtying logic requires both a metatileentity and a holder
+        try {
+            Field field = MetaTileEntity.class.getDeclaredField("holder");
+            field.setAccessible(true);
+            field.set(mbt, new MetaTileEntityHolder());
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            Field field = MetaTileEntityHolder.class.getDeclaredField("metaTileEntity");
+            field.setAccessible(true);
+            field.set(mbt.getHolder(), mbt);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        mbt.getHolder().setWorld(world);
+
+        try {
+            Field field = RecipeMapMultiblockController.class.getDeclaredField("isDistinct");
+            field.setAccessible(true);
+            field.setBoolean(mbt, true);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+
+        //Controller and isAttachedToMultiBlock need the world so we fake it here.
+        MetaTileEntityItemBus importItemBus = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, false) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+        MetaTileEntityItemBus importItemBus2 = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, false) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+        MetaTileEntityItemBus exportItemBus = new MetaTileEntityItemBus(gregtechId("item_bus.export.lv"), 1, true) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+        MetaTileEntityFluidHatch importFluidBus = new MetaTileEntityFluidHatch(gregtechId("fluid_hatch.import.lv"), 1, false) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+        MetaTileEntityFluidHatch exportFluidBus = new MetaTileEntityFluidHatch(gregtechId("fluid_hatch.export.lv"), 1, true) {
+            @Override
+            public boolean isAttachedToMultiBlock() {
+                return true;
+            }
+
+            @Override
+            public MultiblockControllerBase getController() {
+                return mbt;
+            }
+        };
+
+        //Controller is a private field but we need that information
+        try {
+            Field field = MetaTileEntityMultiblockPart.class.getDeclaredField("controllerTile");
+            field.setAccessible(true);
+            field.set(importItemBus, mbt);
+            field.set(importItemBus2, mbt);
+            field.set(exportItemBus, mbt);
+            field.set(importFluidBus, mbt);
+            field.set(exportFluidBus, mbt);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        MultiblockRecipeLogic mbl = new MultiblockRecipeLogic(mbt) {
+
+            @Override
+            protected long getEnergyStored() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected long getEnergyCapacity() {
+                return Long.MAX_VALUE;
+            }
+
+            @Override
+            protected boolean drawEnergy(int recipeEUt) {
+                return true;
+            }
+
+            @Override
+            protected long getMaxVoltage() {
+                return 32;
+            }
+
+            // since the hatches were not really added to a valid multiblock structure,
+            // refer to their inventories directly
+            @Override
+            protected IItemHandlerModifiable getInputInventory() {
+                return importItemBus.getImportItems();
+            }
+
+            @Override
+            protected IItemHandlerModifiable getOutputInventory() {
+                return exportItemBus.getExportItems();
+            }
+
+            @Override
+            protected IMultipleTankHandler getInputTank() {
+                return importFluidBus.getImportFluids();
+            }
+
+            @Override
+            protected IMultipleTankHandler getOutputTank() {
+                return importFluidBus.getExportFluids();
+            }
+
+            @Override
+            protected List<IItemHandlerModifiable> getInputBuses() {
+                List<IItemHandlerModifiable> a = new ArrayList<>();
+                a.add(importItemBus.getImportItems());
+                a.add(importItemBus2.getImportItems());
+                return a;
+            }
+
+        };
+
+        assertTrue(mbt.isDistinct());
+
+        mbl.isOutputsFull = false;
+        mbl.invalidInputsForRecipes = false;
+        mbl.trySearchNewRecipe();
+
+        // no recipe found
+        assertTrue(mbt.isDistinct());
+        assertTrue(mbl.invalidatedInputList.containsAll(mbl.getInputBuses()));
+        assertFalse(mbl.isActive);
+        assertNull(mbl.previousRecipe);
+
+        // put an item in the first input bus that will trigger recipe recheck
+
+        IItemHandlerModifiable firstBus = mbl.getInputBuses().get(0);
+        firstBus.insertItem(0, new ItemStack(Blocks.COBBLESTONE, 16), false);
+
+        // Inputs change. did we detect it ?
+        assertTrue(mbl.hasNotifiedInputs());
+        assertTrue(mbl.getMetaTileEntity().getNotifiedItemInputList().contains(firstBus));
+        mbl.trySearchNewRecipe();
+        assertFalse(mbl.invalidatedInputList.contains(firstBus));
+        assertNotNull(mbl.previousRecipe);
+        assertTrue(mbl.isActive);
+        assertEquals(15, firstBus.getStackInSlot(0).getCount());
         //assert the consumption of the inputs did not mark the arl to look for a new recipe
         assertFalse(mbl.hasNotifiedInputs());
 

--- a/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
+++ b/src/test/java/gregtech/api/capability/impl/MultiblockRecipeLogicTest.java
@@ -11,17 +11,13 @@ import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
-import gregtech.api.unification.material.MaterialRegistry;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
-import gregtech.api.util.Position;
 import gregtech.api.util.world.DummyWorld;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityFluidHatch;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityItemBus;
-import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMufflerHatch;
 import gregtech.common.metatileentities.electric.multiblockpart.MetaTileEntityMultiblockPart;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityElectricBlastFurnace;
-import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Bootstrap;
 import net.minecraft.item.ItemStack;
@@ -317,7 +313,7 @@ public class MultiblockRecipeLogicTest {
                 .buildAndRegister();
 
         RecipeMapMultiblockController mbt =
-                GregTechAPI.registerMetaTileEntity(511,
+                GregTechAPI.registerMetaTileEntity(512,
                         new MetaTileEntityElectricBlastFurnace(
                                 // super function calls the world, which equal null in test
                                 new ResourceLocation(GTValues.MODID, "electric_blast_furnace")) {


### PR DESCRIPTION
**What:**
This PR implements Distinct buses, as they were implemented in https://github.com/Gregicality/gregicality/pull/451. There have been some changes since that PR in how the distinct buses were implemented, mainly due to #91 and so I will attempt to explain them.


### Changes from the Gregicality PR:

- The Logic override for `checkRecipeInputsDirty` has been removed, as this no longer exists due to the rewrite in #91.
- Instead of having an entirely new `setupAndConsumeRecipeInputs` where the only major change was checking a specific bus, `setupAndConsumeRecipeInputs` got another parameter added, for the inventory handler that the Recipe is coming from. In the case of multiblocks not in distinct mode, this is simply the combined inventory handler, however for multiblocks in distinct mode, this is the specific bus that the ingredients for the recipe were found in.
- Attempts to implement the notifiable status introduced in #91.



I have left several implementation questions that I am seeking feedback on in the form of TODOs, so feedback on them would be appreciated.

I am also looking for feedback on any other multiblocks that should not have the ability to be distinct. Currently, the Fusion Reactor and the Large Chemical Reactor are the only multiblocks that cannot have distinct buses.

**Outcome:**
Implements distinct buses for GTCE Multiblocks

