### PR TITLE
Slight nerf to Multismelter rates

### DIFF
--- a/src/main/java/gregtech/common/blocks/BlockWireCoil.java
+++ b/src/main/java/gregtech/common/blocks/BlockWireCoil.java
@@ -57,13 +57,13 @@ public class BlockWireCoil extends VariantBlock<BlockWireCoil.CoilType> {
 
         CUPRONICKEL("cupronickel", 1800, 1, 1, Materials.Cupronickel),
         KANTHAL("kanthal", 2700, 2, 1, Materials.Kanthal),
-        NICHROME("nichrome", 3600, 4, 1, Materials.Nichrome),
-        TUNGSTENSTEEL("tungstensteel", 4500, 8, 1, Materials.TungstenSteel),
-        HSS_G("hss_g", 5400, 8, 2, Materials.HSSG),
-        NAQUADAH("naquadah", 7200, 16, 1, Materials.Naquadah),
-        NAQUADAH_ALLOY("naquadah_alloy", 9001, 16, 2, Materials.NaquadahAlloy),
-        FLUXED_ELECTRUM("fluxed_electrum", 10800, 16, 4, Materials.FluxedElectrum),
-        DIAMERICIUM_TITANIUM("diamericium_titanium", 12600, 16, 8, Materials.DiamericiumTitanium);
+        NICHROME("nichrome", 3600, 2, 2, Materials.Nichrome),
+        TUNGSTENSTEEL("tungstensteel", 4500, 4, 2, Materials.TungstenSteel),
+        HSS_G("hss_g", 5400, 4, 4, Materials.HSSG),
+        NAQUADAH("naquadah", 7200, 8, 4, Materials.Naquadah),
+        NAQUADAH_ALLOY("naquadah_alloy", 9001, 8, 8, Materials.NaquadahAlloy),
+        FLUXED_ELECTRUM("fluxed_electrum", 10800, 16, 8, Materials.FluxedElectrum),
+        DIAMERICIUM_TITANIUM("diamericium_titanium", 12600, 16, 16, Materials.DiamericiumTitanium);
 
         private final String name;
         //electric blast furnace properties


### PR DESCRIPTION
**What:**
A slight nerf to multismelter parallel bonuses and a slight buff to its energy bonuses, pushing the better bonuses to the higher tier coils.

Currently, the last 4 tiers of coil will get you the maximum parallel bonus on the multismelter, after this PR it is only the last two tiers of coils. To go with this, the parallel bonuses have been smoothed out as you go higher in coil tier.

Current Parallel Bonus (For the MS, this is 32 * this number recipes at one time):

1, 2, 4, 8, 8, 16, 16, 16, 16.

In this PR:

1, 2, 2, 4, 4, 8, 8, 16, 16

As you can see, the climb to the best parallel bonus is more smooth, leaving the best bonus to the highest coil tiers

Energy Bonus:

This is calculated as `EUt = Math.max(1, 16 / heatingCoilDiscount)`

Current:

1, 1, 1, 1, 2, 1, 2, 4, 8

In this PR:

1, 1, 2, 2, 4, 4, 8, 8, 16

A much more spread out energy bonus, with a new tier being introduced and preventing the energy bonus from decreasing with higher tier coils. I made this scale to be tied in with the parallel bonus, with the second coil of the same level (eg: 2, 2 <- this one) receiving the energy bonus, to still have a reason to improve coils, rather than just skipping every other tier.

Combined, this achieves the effect of slightly nerfing the multismelter, while still having a reason to progress in coils tiers.

Looking for comments and feedback on this PR.

**Outcome:**
Slight nerf to Multismelter rates