### PR TITLE
Begin work on implementing parallel logic

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/AbstractRecipeLogic.java
@@ -6,9 +6,11 @@ import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.metatileentity.MTETrait;
 import gregtech.api.metatileentity.MetaTileEntity;
+import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.RecipeMap;
+import gregtech.api.recipes.logic.ParallelLogic;
 import gregtech.api.util.GTUtility;
 import gregtech.common.ConfigHolder;
 import net.minecraft.item.ItemStack;
@@ -16,12 +18,12 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.network.PacketBuffer;
 import net.minecraft.util.NonNullList;
+import net.minecraft.util.Tuple;
 import net.minecraft.world.*;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
-import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import java.util.ArrayList;
@@ -44,6 +46,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
     protected int progressTime;
     protected int maxProgressTime;
     protected int recipeEUt;
+    protected int parallelRecipesPerformed = 1;
     protected List<FluidStack> fluidOutputs;
     protected NonNullList<ItemStack> itemOutputs;
     protected final Random random = new Random();
@@ -208,8 +211,24 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         this.invalidInputsForRecipes = (currentRecipe == null);
 
         // proceed if we have a usable recipe.
-        if (currentRecipe != null && setupAndConsumeRecipeInputs(currentRecipe, importInventory))
-            setupRecipe(currentRecipe);
+        if (currentRecipe != null) {
+
+            //Check if the recipe needs to be multiplied due to parallel logic
+            if(this.metaTileEntity instanceof MultiblockWithDisplayBase) {
+                Tuple<Recipe, Integer> multipliedRecipe = ParallelLogic.multiplyRecipe(currentRecipe, this.recipeMap, importInventory, importFluids, ((MultiblockWithDisplayBase) this.metaTileEntity).getParallelLimit());
+
+                // Multiply the recipe if we can
+                if(multipliedRecipe != null) {
+                    currentRecipe = multipliedRecipe.getFirst();
+                    this.parallelRecipesPerformed = multipliedRecipe.getSecond();
+                }
+            }
+
+            if(setupAndConsumeRecipeInputs(currentRecipe, importInventory)) {
+                setupRecipe(currentRecipe);
+            }
+
+        }
         // Inputs have been inspected.
         metaTileEntity.getNotifiedItemInputList().clear();
         metaTileEntity.getNotifiedFluidInputList().clear();
@@ -249,15 +268,37 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
      * @return - true if the recipe is successful, false if the recipe is not successful
      */
     protected boolean setupAndConsumeRecipeInputs(Recipe recipe, IItemHandlerModifiable importInventory) {
-        int[] resultOverclock = calculateOverclock(recipe.getEUt(), recipe.getDuration());
-        int totalEUt = resultOverclock[0] * resultOverclock[1];
+
+        //Format: EU/t, Duration
+        int[] resultOverclock = calculateOverclock(recipe.getEUt(), this.overclockPolicy.getAsLong(), recipe.getDuration());
+        int totalEUt = resultOverclock[0] * resultOverclock[1] * this.parallelRecipesPerformed;
+
         IItemHandlerModifiable exportInventory = getOutputInventory();
         IMultipleTankHandler importFluids = getInputTank();
         IMultipleTankHandler exportFluids = getOutputTank();
-        if (!(totalEUt >= 0 ? getEnergyStored() >= (totalEUt > getEnergyCapacity() / 2 ? resultOverclock[0] : totalEUt) :
-            (getEnergyStored() - resultOverclock[0] <= getEnergyCapacity()))) {
+
+        boolean enoughPower;
+        //RIP Ternary
+        if(totalEUt >= 0) {
+            int capacity;
+            if(totalEUt > getEnergyCapacity() / 2) {
+                capacity = resultOverclock[0];
+            }
+            else {
+                capacity = totalEUt;
+            }
+
+            enoughPower = getEnergyStored() >= capacity;
+        }
+        else {
+            int power = resultOverclock[0] * this.parallelRecipesPerformed;
+            enoughPower = getEnergyStored() - (long) power <= getEnergyCapacity();
+        }
+
+        if(!enoughPower) {
             return false;
         }
+
         if (!MetaTileEntity.addItemsToItemHandler(exportInventory, true, recipe.getAllItemOutputs(exportInventory.getSlots()))) {
             this.isOutputsFull = true;
             return false;
@@ -268,10 +309,6 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         }
         this.isOutputsFull = false;
         return recipe.matches(true, importInventory, importFluids);
-    }
-
-    protected int[] calculateOverclock(int EUt, int duration) {
-        return calculateOverclock(EUt, this.overclockPolicy.getAsLong(), duration);
     }
 
     protected int[] calculateOverclock(int EUt, long voltage, int duration) {
@@ -319,10 +356,10 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
     }
 
     protected void setupRecipe(Recipe recipe) {
-        int[] resultOverclock = calculateOverclock(recipe.getEUt(), recipe.getDuration());
+        int[] resultOverclock = calculateOverclock(recipe.getEUt(), this.overclockPolicy.getAsLong(), recipe.getDuration());
         this.progressTime = 1;
         setMaxProgress(resultOverclock[1]);
-        this.recipeEUt = resultOverclock[0];
+        this.recipeEUt = resultOverclock[0] * this.parallelRecipesPerformed;
         this.fluidOutputs = GTUtility.copyFluidList(recipe.getFluidOutputs());
         int tier = getMachineTierForRecipe(recipe);
         this.itemOutputs = GTUtility.copyStackList(recipe.getResultItemOutputs(getOutputInventory().getSlots(), random, tier));
@@ -347,6 +384,7 @@ public abstract class AbstractRecipeLogic extends MTETrait implements IWorkable 
         this.itemOutputs = null;
         this.hasNotEnoughEnergy = false;
         this.wasActiveAndNeedsUpdate = true;
+        this.parallelRecipesPerformed = 1;
     }
 
     public double getProgressPercent() {

--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -7,6 +7,8 @@ import gregtech.api.metatileentity.multiblock.MultiblockWithDisplayBase;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import gregtech.api.recipes.MatchingMode;
 import gregtech.api.recipes.Recipe;
+import gregtech.api.recipes.logic.ParallelLogic;
+import net.minecraft.util.Tuple;
 import net.minecraftforge.items.IItemHandlerModifiable;
 
 import java.util.ArrayList;
@@ -107,12 +109,20 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
             }
         }
 
+        trySearchNewRecipeCombined();
+    }
+
+    /**
+     * Put into place so multiblocks can override {@link AbstractRecipeLogic#trySearchNewRecipe()} without having to deal with
+     * the maintenance and distinct logic in {@link MultiblockRecipeLogic#trySearchNewRecipe()}
+     */
+    protected void trySearchNewRecipeCombined() {
         super.trySearchNewRecipe();
     }
 
     protected void trySearchNewRecipeDistinct() {
         long maxVoltage = getMaxVoltage();
-        Recipe currentRecipe = null;
+        Recipe currentRecipe;
         List<IItemHandlerModifiable> importInventory = getInputBuses();
         IMultipleTankHandler importFluids = getInputTank();
 
@@ -130,6 +140,18 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         // This guarantees that if we get a recipe cache hit, our efficiency is no different from other machines
         if (previousRecipe != null && previousRecipe.matches(false, importInventory.get(lastRecipeIndex), importFluids)) {
             currentRecipe = previousRecipe;
+
+            // Perform Parallel Logic
+            if(this.metaTileEntity instanceof MultiblockWithDisplayBase) {
+                Tuple<Recipe, Integer> multipliedRecipe = ParallelLogic.multiplyRecipe(currentRecipe, this.recipeMap, importInventory.get(lastRecipeIndex), importFluids, ((MultiblockWithDisplayBase) this.metaTileEntity).getParallelLimit());
+
+                // Multiply the recipe if we can
+                if(multipliedRecipe != null) {
+                    currentRecipe = multipliedRecipe.getFirst();
+                    this.parallelRecipesPerformed = multipliedRecipe.getSecond();
+                }
+            }
+
             // If a valid recipe is found, immediately attempt to return it to prevent inventory scanning
             if (setupAndConsumeRecipeInputs(currentRecipe, importInventory.get(lastRecipeIndex))) {
                 setupRecipe(currentRecipe);
@@ -156,6 +178,19 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
             // Cache the current recipe, if one is found
             if (currentRecipe != null) {
                 this.previousRecipe = currentRecipe;
+
+                // Perform Parallel Logic
+                if(this.metaTileEntity instanceof MultiblockWithDisplayBase) {
+                    Tuple<Recipe, Integer> multipliedRecipe = ParallelLogic.multiplyRecipe(currentRecipe, this.recipeMap, bus, importFluids, ((MultiblockWithDisplayBase) this.metaTileEntity).getParallelLimit());
+
+                    // Multiply the recipe if we can
+                    if(multipliedRecipe != null) {
+                        currentRecipe = multipliedRecipe.getFirst();
+                        this.parallelRecipesPerformed = multipliedRecipe.getSecond();
+                    }
+
+                }
+
                 if (setupAndConsumeRecipeInputs(currentRecipe, importInventory.get(i))) {
                     lastRecipeIndex = i;
                     setupRecipe(currentRecipe);

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -380,4 +380,8 @@ public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase
             return abilityPartPredicate(MultiblockAbility.MAINTENANCE_HATCH).or(statePredicate(allowedAlternatives));
         } else return statePredicate(allowedAlternatives);
     }
+
+    public int getParallelLimit() {
+        return 1;
+    }
 }

--- a/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
+++ b/src/main/java/gregtech/api/recipes/logic/ParallelLogic.java
@@ -3,6 +3,7 @@ package gregtech.api.recipes.logic;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.recipes.*;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.Tuple;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidTank;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -24,10 +25,10 @@ public class ParallelLogic {
      * @param parallelAmount The hard limit on the amount of parallel Recipes that can be performed
      * @return A Recipe that has had all factors scaled by the number of parallel operations
      */
-    protected Recipe multiplyRecipe(Recipe recipe, RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, int parallelAmount) {
+    public static Tuple<Recipe, Integer> multiplyRecipe(Recipe recipe, RecipeMap<?> recipeMap, IItemHandlerModifiable inputs, IMultipleTankHandler fluidInputs, int parallelAmount) {
 
         if(parallelAmount == 1) {
-            return recipe;
+            return new Tuple<>(recipe, parallelAmount);
         }
 
         // Find all the items in the combined Item Input inventories and create oversized ItemStacks
@@ -56,7 +57,7 @@ public class ParallelLogic {
         List<FluidStack> outputFluids = new ArrayList<>();
 
         // Populate the various holders of the multiplied Recipe
-        this.multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputItems, outputFluids, recipe, minMultiplier);
+        multiplyInputsAndOutputs(newRecipeInputs, newFluidInputs, outputItems, outputFluids, recipe, minMultiplier);
 
         // Build the new Recipe with multiplied components
         RecipeBuilder<?> newRecipe = recipeMap.recipeBuilder()
@@ -71,7 +72,7 @@ public class ParallelLogic {
         copyChancedItemOutputs(newRecipe, recipe, minMultiplier);
 
         // Return the multiplied Recipe
-        return newRecipe.build().getResult();
+        return new Tuple<>(newRecipe.build().getResult(), minMultiplier);
     }
 
     /**
@@ -148,7 +149,7 @@ public class ParallelLogic {
      * @param parallelAmount The limit on the amount of recipes that can be performed at one time
      * @return The Maximum number of Recipes that can be performed at a single time based on the available Items
      */
-    protected int getMinRatioItem(Set<ItemStack> countIngredients, Recipe recipe, int parallelAmount) {
+    protected static int getMinRatioItem(Set<ItemStack> countIngredients, Recipe recipe, int parallelAmount) {
 
         int minMultiplier = Integer.MAX_VALUE;
 
@@ -235,7 +236,7 @@ public class ParallelLogic {
      * @param parallelAmount The limit on the amount of recipes that can be performed at one time
      * @return The Maximum number of Recipes that can be performed at a single time based on the available Fluids
      */
-    protected int getMinRatioFluid(Set<FluidStack> countFluid, Recipe recipe, int parallelAmount) {
+    protected static int getMinRatioFluid(Set<FluidStack> countFluid, Recipe recipe, int parallelAmount) {
 
         int minMultiplier = Integer.MAX_VALUE;
 
@@ -279,7 +280,7 @@ public class ParallelLogic {
         return fluidCopy;
     }
 
-    protected void multiplyInputsAndOutputs(List<CountableIngredient> newRecipeInputs,
+    protected static void multiplyInputsAndOutputs(List<CountableIngredient> newRecipeInputs,
                                             List<FluidStack> newFluidInputs,
                                             List<ItemStack> outputItems,
                                             List<FluidStack> outputFluids,

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityMultiSmelter.java
@@ -121,9 +121,7 @@ public class MetaTileEntityMultiSmelter extends RecipeMapMultiblockController {
         }
 
         @Override
-        protected void trySearchNewRecipe() {
-            if (((RecipeMapMultiblockController) metaTileEntity).getNumMaintenanceProblems() > 5)
-                return;
+        protected void trySearchNewRecipeCombined() {
 
             long maxVoltage = getMaxVoltage();
             Recipe currentRecipe = null;


### PR DESCRIPTION
**What:**
A PR for implementing parallel logic for multiblocks through the recently added Parallel Logic helper. I am definitely looking for feedback on this PR, so any will be welcome.

The current method to specify parallel abilities is overriding `getParallelLimit` in the multiblock's specific class. It was done this way and not on the workable for a few reasons. One was that the steam multiblocks directly extend `AbstractRecipeLogic` instead of `MultiblockRecipeLogic`, so the parallel logic would have to be specified in that class, which also deals with single block machines. The second is that if it was implemented in the Logic classes, Multiblocks that want to perform parallel recipes would have to create custom workable subclasses just to override the method.

A new instance variable has been introduced in `AbstractRecipeLogic`, which is `parallelRecipePerformed`, which takes one of the outputs of `multiplyRecipe` and stores it for use later to multiply the EU costs of the recipe. This value is reset when the recipe is completed.

A slight change to `trySearchNewRecipe` in `MultiblockRecipeLogic`, instead of calling `super` directly, it will instead call a new method that normally calls super.  This is done for Multiblocks to more easily override `AbstractRecipeLogic#trySearchNewRecipe` without having to deal with the maintenance or distinct logic implementation in `MultiblockRecipeLogic#trySearchNewRecipe`.

Still TODO: Implement a parallel method that will behave like the multismelter, and take the status of the output bus into consideration when finding the maximum number of recipes that can be performed. Ideally this method will deal with both fluids and items. After completion, migrate the multismelter and the two steam multiblocks to use this method.

**Outcome:**
Implements parallel logic