### PR TITLE
Allow CT to add flags to existing materials

### DIFF
--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -112,10 +112,22 @@ public class Material implements Comparable<Material> {
     }
 
     @ZenMethod
-    public void addFlag(MaterialFlag... flags) {
+    public void addFlags(MaterialFlag... flags) {
         if (MaterialRegistry.isFrozen())
             throw new IllegalStateException("Cannot add flag to material when registry is frozen!");
         this.flags.addFlags(flags).verify(this);
+    }
+
+    @ZenMethod
+    public void addFlags(String... names) {
+        if (MaterialRegistry.isFrozen())
+            throw new IllegalStateException("Cannot add flag to material when registry is frozen!");
+
+        for (String name : names) {
+            MaterialFlag flag = MaterialFlag.getByName(name.toLowerCase());
+            if (flag != null)
+                this.flags.addFlags(flag).verify(this);
+        }
     }
 
     public boolean hasFlag(MaterialFlag flag) {

--- a/src/main/java/gregtech/api/unification/material/Material.java
+++ b/src/main/java/gregtech/api/unification/material/Material.java
@@ -19,10 +19,7 @@ import net.minecraftforge.fluids.FluidStack;
 import stanhebben.zenscript.annotations.*;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 @ZenClass("mods.gregtech.material.Material")
 @ZenRegister
@@ -111,7 +108,6 @@ public class Material implements Comparable<Material> {
         MaterialRegistry.register(this);
     }
 
-    @ZenMethod
     public void addFlags(MaterialFlag... flags) {
         if (MaterialRegistry.isFrozen())
             throw new IllegalStateException("Cannot add flag to material when registry is frozen!");
@@ -120,14 +116,10 @@ public class Material implements Comparable<Material> {
 
     @ZenMethod
     public void addFlags(String... names) {
-        if (MaterialRegistry.isFrozen())
-            throw new IllegalStateException("Cannot add flag to material when registry is frozen!");
-
-        for (String name : names) {
-            MaterialFlag flag = MaterialFlag.getByName(name.toLowerCase());
-            if (flag != null)
-                this.flags.addFlags(flag).verify(this);
-        }
+        addFlags(Arrays.stream(names)
+                .map(MaterialFlag::getByName)
+                .filter(Objects::nonNull)
+                .toArray(MaterialFlag[]::new));
     }
 
     public boolean hasFlag(MaterialFlag flag) {


### PR DESCRIPTION
CT could previously not add flags to existing materials, due the method requiring MaterialFlag objects. An overloaded method was added to allow addition with String keys.