### PR TITLE
Many Small Cleanups

### DIFF
--- a/src/main/java/gregtech/integration/jei/GTOreCategory.java
+++ b/src/main/java/gregtech/integration/jei/GTOreCategory.java
@@ -4,7 +4,7 @@ import gregtech.api.gui.GuiTextures;
 import gregtech.api.util.GTLog;
 import gregtech.api.worldgen.config.OreDepositDefinition;
 import gregtech.api.worldgen.config.WorldGenRegistry;
-import gregtech.integration.jei.recipe.primitive.PrimitiveRecipeCategory;
+import gregtech.integration.jei.recipe.primitive.BasicRecipeCategory;
 import it.unimi.dsi.fastutil.ints.IntSortedSet;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.gui.IDrawable;
@@ -24,7 +24,7 @@ import java.util.function.Supplier;
 import static gregtech.api.GTValues.MODID_AR;
 import static gregtech.api.GTValues.isModLoaded;
 
-public class GTOreCategory extends PrimitiveRecipeCategory<GTOreInfo, GTOreInfo> {
+public class GTOreCategory extends BasicRecipeCategory<GTOreInfo, GTOreInfo> {
 
     protected final IDrawable slot;
     protected OreDepositDefinition definition;

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/BasicRecipeCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/BasicRecipeCategory.java
@@ -14,14 +14,13 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
-// TODO Should be renamed to "BasicRecipeCategory"
-public abstract class PrimitiveRecipeCategory<T, W extends IRecipeWrapper> implements IRecipeCategory<W>, IRecipeWrapperFactory<T> {
+public abstract class BasicRecipeCategory<T, W extends IRecipeWrapper> implements IRecipeCategory<W>, IRecipeWrapperFactory<T> {
 
     public final String uniqueName;
     public final String localizedName;
     protected final IDrawable background;
 
-    public PrimitiveRecipeCategory(String uniqueName, String localKey, IDrawable background, IGuiHelper guiHelper) {
+    public BasicRecipeCategory(String uniqueName, String localKey, IDrawable background, IGuiHelper guiHelper) {
         this.uniqueName = uniqueName;
         this.localizedName = I18n.format(localKey);
         this.background = background;

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTreeCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/MaterialTreeCategory.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.ArrayList;
 
-public class MaterialTreeCategory extends PrimitiveRecipeCategory<MaterialTree, MaterialTree> {
+public class MaterialTreeCategory extends BasicRecipeCategory<MaterialTree, MaterialTree> {
 
     protected String materialName;
     protected String materialFormula;

--- a/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProductCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/primitive/OreByProductCategory.java
@@ -10,7 +10,7 @@ import net.minecraft.client.Minecraft;
 
 import javax.annotation.Nonnull;
 
-public class OreByProductCategory extends PrimitiveRecipeCategory<OreByProduct, OreByProduct> {
+public class OreByProductCategory extends BasicRecipeCategory<OreByProduct, OreByProduct> {
 
     protected final IDrawable slot;
     protected final IDrawable arrowBackground;

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -96,7 +96,6 @@ public class MaterialRecipeHandler {
                     ModHandler.addSmeltingRecipe(new UnificationEntry(dustPrefix, mat), ingotStack);
                 } else {
                     int duration = Math.max(1, (int) (mat.getAverageMass() * blastTemp / 50L));
-                    ModHandler.removeFurnaceSmelting(new UnificationEntry(OrePrefix.ingot, mat));
 
                     BlastRecipeBuilder ingotSmeltingBuilder = RecipeMaps.BLAST_RECIPES.recipeBuilder()
                             .input(dustPrefix, mat)

--- a/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/CircuitRecipes.java
@@ -551,14 +551,6 @@ public class CircuitRecipes {
                 .output(GRAVI_STAR)
                 .buildAndRegister();
 
-        // Neutron Reflector TODO Move out of here
-        ASSEMBLER_RECIPES.recipeBuilder().duration(4000).EUt(120)
-                .input(PLATE_IRIDIUM_ALLOY)
-                .input(plateDouble, Beryllium, 16)
-                .input(plateDouble, TungstenCarbide, 2)
-                .fluidInputs(TinAlloy.getFluid(L * 32))
-                .output(NEUTRON_REFLECTOR)
-                .buildAndRegister();
     }
 
     private static void boardRecipes() {

--- a/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/ComponentRecipes.java
@@ -9,7 +9,6 @@ import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
 import gregtech.common.items.MetaItems;
-import net.minecraftforge.fluids.FluidStack;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,8 +18,6 @@ import static gregtech.common.items.MetaItems.FLUID_REGULATORS;
 import static gregtech.common.items.MetaItems.PUMPS;
 
 public class ComponentRecipes {
-
-    private static final FluidStack[] pumpFluids = {Materials.Rubber.getFluid(L), Materials.StyreneButadieneRubber.getFluid((L * 3) / 4), Materials.SiliconeRubber.getFluid(L / 2)};
 
     public static void register() {
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -925,5 +925,9 @@ public class MachineRecipeLoader {
         ModHandler.addShapelessRecipe("tank_nbt_stainless_steel", MetaTileEntities.STAINLESS_STEEL_TANK.getStackForm(), MetaTileEntities.STAINLESS_STEEL_TANK.getStackForm());
         ModHandler.addShapelessRecipe("tank_nbt_titanium", MetaTileEntities.TITANIUM_TANK.getStackForm(), MetaTileEntities.TITANIUM_TANK.getStackForm());
         ModHandler.addShapelessRecipe("tank_nbt_tungstensteel", MetaTileEntities.TUNGSTENSTEEL_TANK.getStackForm(), MetaTileEntities.TUNGSTENSTEEL_TANK.getStackForm());
+
+        //Jetpacks
+        ModHandler.addShapelessRecipe("fluid_jetpack_clear", SEMIFLUID_JETPACK.getStackForm(), SEMIFLUID_JETPACK.getStackForm());
+
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MiscRecipeLoader.java
@@ -325,12 +325,12 @@ public class MiscRecipeLoader {
                 .inputs(NANO_MUSCLE_SUITE_HELMET.getStackForm())
                 .outputs(QUARK_TECH_SUITE_HELMET.getStackForm())
                 .buildAndRegister();
-//TODO add superconductors when added
+
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(1800).EUt(7100)
                 .inputs(FIELD_GENERATOR_IV.getStackForm())
                 .inputs(FIELD_GENERATOR_EV.getStackForm(2))
                 .input(circuit, Master, 4)
-                // .input(wireGtSingle, IVSuperconductor, 4)
+                .input(wireGtSingle, SamariumIronArsenicOxide, 4)
                 .inputs(POWER_INTEGRATED_CIRCUIT.getStackForm(4))
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .outputs(GRAVITATION_ENGINE.getStackForm())
@@ -338,7 +338,7 @@ public class MiscRecipeLoader {
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(3600).EUt(8192)
                 .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(16))
-                // .input(wireGtSingle, IVSuperconductor, 8)
+                .input(wireGtSingle, SamariumIronArsenicOxide, 8)
                 .inputs(GRAVITATION_ENGINE.getStackForm(2))
                 .inputs(PLATE_IRIDIUM_ALLOY.getStackForm(12))
                 .input(circuit, Elite, 4)
@@ -349,7 +349,7 @@ public class MiscRecipeLoader {
 
         ASSEMBLY_LINE_RECIPES.recipeBuilder().duration(3600).EUt(8192)
                 .inputs(HIGH_POWER_INTEGRATED_CIRCUIT.getStackForm(8))
-                // .input(wireGtSingle, IVSuperconductor, 8)
+                .input(wireGtSingle, SamariumIronArsenicOxide, 8)
                 .inputs(GRAVITATION_ENGINE.getStackForm(2))
                 .inputs(PLATE_IRIDIUM_ALLOY.getStackForm(16))
                 .input(circuit, Elite, 2)
@@ -357,7 +357,6 @@ public class MiscRecipeLoader {
                 .fluidInputs(SolderingAlloy.getFluid(L * 8))
                 .outputs(ADVANCED_QUARK_TECH_SUITE_CHESTPLATE.getStackForm())
                 .buildAndRegister();
-        ModHandler.addShapelessRecipe("fluid_jetpack_clear", SEMIFLUID_JETPACK.getStackForm(), SEMIFLUID_JETPACK.getStackForm());
 
     }
 }

--- a/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaOverrideRecipes.java
@@ -576,7 +576,7 @@ public class VanillaOverrideRecipes {
      * Replaces Vanilla Enchantment Table recipe
      * Replaces Vanilla Jukebox recipe
      * Replaces Vanilla Note Block recipe
-     * Replaces Vanilla Furance
+     * Replaces Vanilla Furnace
      * - Removes Vanilla TNT recipe
      * - Removes Vanilla Golden Apple Recipe
      * - Removes Vanilla Ender Eye Recipe
@@ -691,8 +691,7 @@ public class VanillaOverrideRecipes {
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:polished_diorite"));
         ModHandler.removeRecipeByName(new ResourceLocation("minecraft:polished_andesite"));
 
-        //todo this doesn't work
-        ModHandler.removeFurnaceSmelting(new ItemStack(Items.CLAY_BALL));
+        ModHandler.removeFurnaceSmelting(new ItemStack(Items.CLAY_BALL, 1, GTValues.W));
     }
 
     /**

--- a/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/VanillaStandardRecipes.java
@@ -315,7 +315,7 @@ public class VanillaStandardRecipes {
         LASER_ENGRAVER_RECIPES.recipeBuilder()
                 .inputs(new ItemStack(Blocks.PURPUR_BLOCK))
                 .notConsumable(craftingLens, MarkerMaterials.Color.White)
-                .outputs(new ItemStack(Blocks.PURPUR_PILLAR, 1, 1))
+                .outputs(new ItemStack(Blocks.PURPUR_PILLAR, 1))
                 .duration(50).EUt(16).buildAndRegister();
     }
 

--- a/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
+++ b/src/main/java/gregtech/loaders/recipe/WoodMachineRecipes.java
@@ -61,7 +61,6 @@ public class WoodMachineRecipes {
             }
 
 
-            //todo prevent rubber wood from making jungle slabs
             CUTTER_RECIPES.recipeBuilder().inputs(stack)
                     .fluidInputs(Lubricant.getFluid(1))
                     .outputs(GTUtility.copyAmount((int) (originalOutput * 1.5), plankStack), OreDictUnifier.get(dust, Wood, 2))

--- a/src/main/java/gregtech/loaders/recipe/chemistry/AssemblerRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/chemistry/AssemblerRecipeLoader.java
@@ -4,6 +4,7 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
+import static gregtech.api.GTValues.L;
 import static gregtech.api.recipes.RecipeMaps.ASSEMBLER_RECIPES;
 import static gregtech.api.unification.material.Materials.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
@@ -259,6 +260,15 @@ public class AssemblerRecipeLoader {
                 .input(wireFine, FluxedElectrum, 16)
                 .circuitMeta(1)
                 .outputs(VOLTAGE_COIL_UV.getStackForm())
+                .buildAndRegister();
+
+        // Neutron Reflector
+        ASSEMBLER_RECIPES.recipeBuilder().duration(4000).EUt(120)
+                .input(PLATE_IRIDIUM_ALLOY)
+                .input(plateDouble, Beryllium, 16)
+                .input(plateDouble, TungstenCarbide, 2)
+                .fluidInputs(TinAlloy.getFluid(L * 32))
+                .output(NEUTRON_REFLECTOR)
                 .buildAndRegister();
     }
 }


### PR DESCRIPTION
**What:**
This PR takes care of a couple small TODOs and issues

- Renames `PrimitiveRecipeCategory` to `BasicRecipeCategory` since now there are actual things for Primitive machines (was a todo)
- Stops attempting to remove Furnace Recipes from materials that did not have them (noticed in with debug log)
- Moves Neutron Reflector recipe into more fitting place (was a todo)
- Removes unused `pumpFluids` field in the components recipes (noticed it was unused)
- Moves Fluid Jetpack clearing recipe to other clearing recipes (noticed it was not grouped)
- Adds commented out IV Superconductor wires to recipes (was a todo)
- Fixed the clay ball -> brick smelting recipe not getting removed (was a todo)
- Fixes an incorrect recipe for purpur pillar making an item that does not exist (noticed issue)
- Removes an outdated todo about rubber wood -> jungle slabs as it is not applicable anymore

**Outcome:**
Cleans up small todos and issues