### PR TITLE
Fix simple_washer spam

### DIFF
--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -102,11 +102,14 @@ public class GTJeiPlugin implements IModPlugin {
         registry.getRecipeTransferRegistry().addRecipeTransferHandler(modularUIGuiHandler, Constants.UNIVERSAL_RECIPE_TRANSFER_UID);
 
         for (RecipeMap<?> recipeMap : RecipeMap.getRecipeMaps()) {
-            List<GTRecipeWrapper> recipesList = recipeMap.getRecipeList()
-                    .stream().filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay())
-                    .map(GTRecipeWrapper::new)
-                    .collect(Collectors.toList());
-            registry.addRecipes(recipesList, GTValues.MODID + ":" + recipeMap.unlocalizedName);
+            if(!recipeMap.isHidden) {
+                List<GTRecipeWrapper> recipesList = recipeMap.getRecipeList()
+                        .stream()
+                        .filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay())
+                        .map(GTRecipeWrapper::new)
+                        .collect(Collectors.toList());
+                registry.addRecipes(recipesList, GTValues.MODID + ":" + recipeMap.unlocalizedName);
+            }
         }
 
         for (FuelRecipeMap fuelRecipeMap : FuelRecipeMap.getRecipeMaps()) {


### PR DESCRIPTION
**What:**
Fixes the simple_washer log spam by checking if the recipe map is hidden before trying to registry recipes.

**Outcome:**
Fixes log spam