### PR TITLE
Add some clarification tooltips to certain multiblocks

### DIFF
--- a/src/main/java/gregtech/integration/jei/multiblock/infos/LargeCombustionEngineInfo.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/infos/LargeCombustionEngineInfo.java
@@ -13,6 +13,10 @@ import gregtech.integration.jei.multiblock.MultiblockShapeInfo;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
 
 import java.util.List;
 
@@ -46,4 +50,13 @@ public class LargeCombustionEngineInfo extends MultiblockInfoPage {
     public String[] getDescription() {
         return new String[]{I18n.format("gregtech.multiblock.large_combustion_engine.description")};
     }
+
+    @Override
+    protected void generateBlockTooltips() {
+        super.generateBlockTooltips();
+
+        ITextComponent tooltip = new TextComponentTranslation("gregtech.multiblock.preview.clear_amount", 1, 1, 1).setStyle(new Style().setColor(TextFormatting.DARK_RED));
+        addBlockTooltip(MetaBlocks.MULTIBLOCK_CASING.getItemVariant(BlockMultiblockCasing.MultiblockCasingType.ENGINE_INTAKE_CASING), tooltip);
+    }
+
 }

--- a/src/main/java/gregtech/integration/jei/multiblock/infos/LargeTurbineInfo.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/infos/LargeTurbineInfo.java
@@ -17,6 +17,10 @@ import gregtech.integration.jei.multiblock.MultiblockShapeInfo;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumFacing;
+import net.minecraft.util.text.ITextComponent;
+import net.minecraft.util.text.Style;
+import net.minecraft.util.text.TextComponentTranslation;
+import net.minecraft.util.text.TextFormatting;
 
 import java.util.List;
 
@@ -70,5 +74,16 @@ public class LargeTurbineInfo extends MultiblockInfoPage {
     @Override
     public String[] getDescription() {
         return new String[]{I18n.format("gregtech.multiblock.large_turbine.description")};
+    }
+
+    @Override
+    protected void generateBlockTooltips() {
+        super.generateBlockTooltips();
+
+        ITextComponent tooltip = new TextComponentTranslation("gregtech.multiblock.preview.clear_amount", 3, 3, 1).setStyle(new Style().setColor(TextFormatting.DARK_RED));
+        for(MetaTileEntityRotorHolder rotor : MetaTileEntities.ROTOR_HOLDER) {
+            addBlockTooltip(rotor.getStackForm(), tooltip);
+        }
+
     }
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3868,6 +3868,7 @@ gregtech.multiblock.preview.location.t_c=Top Center
 gregtech.multiblock.preview.primitive_pump.hatch=Only Pump Hatch, ULV Hatch, or LV Hatch allowed
 gregtech.multiblock.preview.location_end=Very End
 gregtech.multiblock.preview.distillation_multi_fluid=Quadruple/Nonuple Output Hatches not allowed
+gregtech.multiblock.preview.clear_amount=Must have a clear %dx%dx%d space in front
 
 gregtech.multiblock.blast_furnace.max_temperature=Max Temperature: %sK
 gregtech.multiblock.multi_furnace.heating_coil_level=Heating Coil Level: %s


### PR DESCRIPTION
**What:**
Adds some clarification tooltips to some multiblocks that need empty spaces in front of some of their parts

![2021-09-21_14-20](https://user-images.githubusercontent.com/31759736/134250624-43a0a1da-75fb-4e3b-8409-19e2736fcc7c.png)


**Outcome:**
Adds some clarification tooltips to multiblocks that need empty space in front of some of their parts