### PR TITLE
Remove the typo fix ct method

### DIFF
--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
@@ -51,18 +51,12 @@ public class CTRecipe {
                 .collect(Collectors.toList());
     }
 
-    @ZenGetter("changedOutputs")
-    public List<ChancedEntry> getChancedOutputs() {
+    @ZenGetter("chancedOutputs")
+    public List<ChancedEntry> getChancedOutputsFix() {
         ArrayList<ChancedEntry> result = new ArrayList<>();
         this.backingRecipe.getChancedOutputs().forEach(chanceEntry ->
                 result.add(new ChancedEntry(new MCItemStack(chanceEntry.getItemStack()), chanceEntry.getChance(), chanceEntry.getBoostPerTier())));
         return result;
-    }
-
-    //Typo Fix
-    @ZenGetter("chancedOutputs")
-    public List<ChancedEntry> getChancedOutputsFix() {
-        return getChancedOutputs();
     }
 
     @ZenGetter("fluidInputs")

--- a/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
+++ b/src/main/java/gregtech/api/recipes/crafttweaker/CTRecipe.java
@@ -52,7 +52,7 @@ public class CTRecipe {
     }
 
     @ZenGetter("chancedOutputs")
-    public List<ChancedEntry> getChancedOutputsFix() {
+    public List<ChancedEntry> getChancedOutputs() {
         ArrayList<ChancedEntry> result = new ArrayList<>();
         this.backingRecipe.getChancedOutputs().forEach(chanceEntry ->
                 result.add(new ChancedEntry(new MCItemStack(chanceEntry.getItemStack()), chanceEntry.getChance(), chanceEntry.getBoostPerTier())));


### PR DESCRIPTION
**What:**
Removes the typo error CT method and use the correctly spelled method. This was not done in GTCE to prevent script breaking.

**Outcome:**
Slight code cleanup