### PR TITLE
JEI Preview Fixes

### DIFF
--- a/src/main/java/gregtech/api/gui/resources/ItemStackTexture.java
+++ b/src/main/java/gregtech/api/gui/resources/ItemStackTexture.java
@@ -1,14 +1,11 @@
 package gregtech.api.gui.resources;
 
-import gregtech.api.gui.widgets.SlotWidget;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Gui;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import org.lwjgl.opengl.GL14;
 
 public class ItemStackTexture implements IGuiTexture{
     private final ItemStack[] itemStack;

--- a/src/main/java/gregtech/api/terminal/TerminalRegistry.java
+++ b/src/main/java/gregtech/api/terminal/TerminalRegistry.java
@@ -92,7 +92,7 @@ public class TerminalRegistry {
                 .device(DeviceHardware.DEVICE.WIRELESS)
                 .build();
         AppRegistryBuilder.create(new BatteryManagerApp()).defaultApp()
-                .battery(GTValues.ULV, 10)
+                .battery(GTValues.ULV, 0)
                 .build();
         AppRegistryBuilder.create(new HardwareManagerApp()).defaultApp().build();
         AppRegistryBuilder.create(new AppStoreApp()).defaultApp().build();

--- a/src/main/java/gregtech/common/terminal/app/hardwaremanager/HardwareSlotWidget.java
+++ b/src/main/java/gregtech/common/terminal/app/hardwaremanager/HardwareSlotWidget.java
@@ -9,6 +9,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 public class HardwareSlotWidget extends WidgetGroup {
@@ -77,9 +78,9 @@ public class HardwareSlotWidget extends WidgetGroup {
             } else {
                 String info = hardware.addInformation();
                 if (info == null) {
-                    drawHoveringText(null, Collections.singletonList(hardware.getLocalizedName()), 300, mouseX, mouseY);
+                    drawHoveringText(null, Arrays.asList(hardware.getLocalizedName(), I18n.format("terminal.hardware.tip.remove")), 300, mouseX, mouseY);
                 } else {
-                    drawHoveringText(null, Collections.singletonList(String.format("%s (%s)", hardware.getLocalizedName(), info)), 300, mouseX, mouseY);
+                    drawHoveringText(null, Arrays.asList(String.format("%s (%s)", hardware.getLocalizedName(), info), I18n.format("terminal.hardware.tip.remove")), 300, mouseX, mouseY);
                 }
             }
         }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoPage.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoPage.java
@@ -43,9 +43,7 @@ public abstract class MultiblockInfoPage {
     }
 
     public List<String> informationText() {
-
-        return Stream.of("gregtech.multiblock.preview.tilt", "gregtech.multiblock.preview.zoom",
-                "gregtech.multiblock.preview.pan", "gregtech.multiblock.preview.move", "gregtech.multiblock.preview.reset")
+        return Stream.of("gregtech.multiblock.preview.zoom")
                 .map(I18n::format)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoPage.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoPage.java
@@ -43,7 +43,7 @@ public abstract class MultiblockInfoPage {
     }
 
     public List<String> informationText() {
-        return Stream.of("gregtech.multiblock.preview.zoom")
+        return Stream.of("gregtech.multiblock.preview.zoom", "gregtech.multiblock.preview.rotate")
                 .map(I18n::format)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -203,6 +203,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             this.currentRendererPage = newIndex;
             this.buttonNextPattern.enabled = newIndex < maxIndex;
             this.buttonPreviousPattern.enabled = newIndex > 0;
+            setNextLayer(-1);
             updateParts();
         }
     }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -89,7 +89,6 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     private Vector3f center;
     private float rotationYaw;
     private float rotationPitch;
-    private float maxZoom;
     private float zoom;
 
     private GuiButton buttonPreviousPattern;
@@ -145,14 +144,13 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         this.buttonNextPattern.enabled = patterns.length > 1;
 
         if (Mouse.getEventDWheel() == 0) {
-            this.maxZoom = infoPage.getDefaultZoom() * 15;
-            this.zoom = this.maxZoom;
+            this.zoom = infoPage.getDefaultZoom() * 15;
             this.rotationYaw = 20.0f;
             this.rotationPitch = 135.0f;
             this.currentRendererPage = 0;
             setNextLayer(-1);
         } else {
-            zoom = (float) MathHelper.clamp(zoom + (Mouse.getEventDWheel() < 0 ? 0.5 : -0.5), 3, maxZoom);
+            zoom = (float) MathHelper.clamp(zoom + (Mouse.getEventDWheel() < 0 ? 0.5 : -0.5), 3, 999);
             setNextLayer(getLayerIndex());
         }
         if (center != null) {
@@ -265,7 +263,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             } else if (rightClickHeld) {
                 int mouseDeltaY = mouseY - lastMouseY;
                 if (Math.abs(mouseDeltaY) > 1) {
-                    this.zoom = (float) MathHelper.clamp(zoom + (mouseDeltaY > 0 ? 0.5 : -0.5), 3, maxZoom);
+                    this.zoom = (float) MathHelper.clamp(zoom + (mouseDeltaY > 0 ? 0.5 : -0.5), 3, 999);
                 }
             }
             renderer.setCameraLookAt(center, zoom, Math.toRadians(rotationPitch), Math.toRadians(rotationYaw));

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -28,6 +28,7 @@ import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.client.resources.I18n;
@@ -44,7 +45,6 @@ import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.text.ITextComponent;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
-import net.minecraftforge.client.model.pipeline.LightUtil;
 import net.minecraftforge.fml.client.config.GuiUtils;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -247,8 +247,6 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             button.drawButton(minecraft, mouseX, mouseY, 0.0f);
         }
 
-        drawHoveringInformationText(minecraft, infoPage.informationText(), mouseX, mouseY);
-
         this.tooltipBlockStack = null;
         RayTraceResult rayTraceResult = renderer.getLastTraceResult();
         boolean insideView = mouseX >= 0 && mouseY >= 0 &&
@@ -269,7 +267,7 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
             renderer.setCameraLookAt(center, zoom, Math.toRadians(rotationPitch), Math.toRadians(rotationYaw));
         }
 
-        if (!(leftClickHeld || rightClickHeld) && rayTraceResult != null && !renderer.world.isAirBlock(rayTraceResult.getBlockPos())) {
+        if (!drawHoveringInformationText(minecraft, infoPage.informationText(), mouseX, mouseY) && !(leftClickHeld || rightClickHeld) && rayTraceResult != null && !renderer.world.isAirBlock(rayTraceResult.getBlockPos())) {
             IBlockState blockState = renderer.world.getBlockState(rayTraceResult.getBlockPos());
             ItemStack itemStack = blockState.getBlock().getPickBlock(blockState, rayTraceResult, renderer.world, rayTraceResult.getBlockPos(), minecraft.player);
             if (itemStack != null && !itemStack.isEmpty()) {
@@ -279,10 +277,14 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
 
         this.lastMouseX = mouseX;
         this.lastMouseY = mouseY;
+
+        GlStateManager.disableRescaleNormal();
+        GlStateManager.disableLighting();
+        RenderHelper.disableStandardItemLighting();
     }
 
     @SideOnly(Side.CLIENT)
-    protected void drawHoveringInformationText(Minecraft minecraft, List<String> tooltip, int mouseX, int mouseY) {
+    protected boolean drawHoveringInformationText(Minecraft minecraft, List<String> tooltip, int mouseX, int mouseY) {
         int minX = recipeLayout.getRecipeCategory().getBackground().getWidth();
         int[] yRange = new int[]{49, 69};
         int[] xRange = new int[]{minX - (ICON_SIZE + RIGHT_PADDING), minX - RIGHT_PADDING};
@@ -290,7 +292,9 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         if (isMouseWithinRange(yRange, xRange, mouseY, mouseX)) {
             GuiUtils.drawHoveringText(tooltip, mouseX, mouseY,
                     176, 176, -1, minecraft.fontRenderer);
+            return true;
         }
+        return false;
     }
 
     private boolean isMouseWithinRange(int[] yRange, int[] xRange, int mouseY, int mouseX) {
@@ -449,6 +453,10 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
     @SideOnly(Side.CLIENT)
     private void renderBlockOverLay(RayTraceResult rayTraceResult) {
         BlockPos pos = rayTraceResult.getBlockPos();
+        GlStateManager.disableDepth();
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE);
+
         Tessellator tessellator = Tessellator.getInstance();
         GlStateManager.disableTexture2D();
         CCRenderState renderState = CCRenderState.instance();
@@ -458,14 +466,16 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper {
         BlockRenderer.BlockFace blockFace = new BlockRenderer.BlockFace();
         renderState.setModel(blockFace);
         for (EnumFacing renderSide : EnumFacing.VALUES) {
-            float diffuse = LightUtil.diffuseLight(renderSide);
-            int color = (int) (255 * diffuse);
-            multiplier.colour = RenderUtil.packColor(color, color, color, 100);
+            multiplier.colour = RenderUtil.packColor(255, 0, 0, 255);
             blockFace.loadCuboidFace(Cuboid6.full, renderSide.getIndex());
             renderState.render();
         }
         renderState.draw();
         GlStateManager.enableTexture2D();
+
+        GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+        GlStateManager.color(1, 1, 1, 1);
+        GlStateManager.enableDepth();
     }
 
 }

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3849,11 +3849,8 @@ gregtech.multiblock.universal.distinct.no=No
 gregtech.multiblock.universal.distinct.yes=Yes
 gregtech.multiblock.universal.distinct.info=If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.
 
-gregtech.multiblock.preview.tilt=Shift+LMB to tilt
-gregtech.multiblock.preview.zoom=Shift+RMB to zoom
-gregtech.multiblock.preview.pan=LMB+Drag to pan
-gregtech.multiblock.preview.move=RMB+Drag to move
-gregtech.multiblock.preview.reset=Scroll Mousewheel to reset
+gregtech.multiblock.preview.zoom=Use mousewheel or Shift+RMB to zoom
+gregtech.multiblock.preview.rotate=Click and drag to rotate
 gregtech.multiblock.preview.any_hatch=Any tier hatch can be used to form the structure
 gregtech.multiblock.preview.any_hatch_maintenance=Any type of maintenance hatch can be used to form the structure
 gregtech.multiblock.preview.limit=Minimum Limit: %d

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -4064,6 +4064,7 @@ terminal.console.controllable=set working enable
 terminal.hardware.description=Hardware Manager, masterpieces of elegance and precision. How can a tablet be without hardware?
 terminal.hardware.select=Mounting hardware
 terminal.hardware.remove=Remove hardware
+terminal.hardware.tip.remove=§4right-click remove the hardware
 
 terminal.battery.description=Battery manager, visually analyzing your app's energy consumption.
 
@@ -4073,7 +4074,7 @@ terminal.store.miss=Require %s (%d).
 
 terminal.ar.open=Open AR
 
-terminal.multiblock_ar.description=Remember the §cFree Wrench§r?  Unfortunately, it it's gone.  It doesn't matter, we have a new technology now. This app can also help you build your multi-block machine.
+terminal.multiblock_ar.description=Remember the §cFree Wrench§r?  Unfortunately, it it's gone. It doesn't matter, we have a new technology now. This app can also help you build your multi-block machine.
 terminal.multiblock_ar.tier.0=AR Camera
 terminal.multiblock_ar.tier.1=3D Builder
 terminal.multiblock_ar.unlock=Unlock this mode after the upgrade

--- a/src/main/resources/assets/gregtech/lang/en_us.lang
+++ b/src/main/resources/assets/gregtech/lang/en_us.lang
@@ -3849,7 +3849,7 @@ gregtech.multiblock.universal.distinct.no=No
 gregtech.multiblock.universal.distinct.yes=Yes
 gregtech.multiblock.universal.distinct.info=If enabled, each Item Input Bus will be treated as fully distinct from each other for recipe lookup. Useful for things like Programmed Circuits, Extruder Shapes, etc.
 
-gregtech.multiblock.preview.zoom=Use mousewheel or Shift+RMB to zoom
+gregtech.multiblock.preview.zoom=Use mousewheel or right-click+Drag to zoom
 gregtech.multiblock.preview.rotate=Click and drag to rotate
 gregtech.multiblock.preview.any_hatch=Any tier hatch can be used to form the structure
 gregtech.multiblock.preview.any_hatch_maintenance=Any type of maintenance hatch can be used to form the structure
@@ -4071,7 +4071,7 @@ terminal.store.miss=Require %s (%d).
 
 terminal.ar.open=Open AR
 
-terminal.multiblock_ar.description=Remember the §cFree Wrench§r?  Unfortunately, it it's gone. It doesn't matter, we have a new technology now. This app can also help you build your multi-block machine.
+terminal.multiblock_ar.description=Remember the §cFreedom Wrench§r?  Unfortunately, it it's gone. It doesn't matter, we have a new technology now. This app can also help you build your multi-block machine.
 terminal.multiblock_ar.tier.0=AR Camera
 terminal.multiblock_ar.tier.1=3D Builder
 terminal.multiblock_ar.unlock=Unlock this mode after the upgrade


### PR DESCRIPTION
Fixed most of the issues mentioned by @ALongStringOfNumbers  in #157 . thanks for review

Fixes as follow:
- There is now a maximum zoom out limit
- Previews start at the maximum zoom level
- Right mouse button will also zoom structure preview **(for zoom in categories)**
- White highlighting over selected blocks
- The highlight layer sometimes renders incorrectly over the block
- Issues when scrolling through the preview JEI categories
- Block tooltips render as well as info when hovering over info icon
- Info icon needs to be updated
- Cannot zoom preview when scrolling through categories **(use right mouse button way)**
- Controllers are rendered full bright in the components section
- Layer not correctly set/reset when changing through multiblock tiers. 

Not covered:
- Weird seam on the corner of a block **(I can't reproduce it)**
- Assembly Line rotates about a fixed point not on multiblock
