### PR TITLE
Fix JEI chanced output display on recipes where the input slots are not full

### DIFF
--- a/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
+++ b/src/main/java/gregtech/integration/jei/GTJeiPlugin.java
@@ -105,7 +105,7 @@ public class GTJeiPlugin implements IModPlugin {
                 List<GTRecipeWrapper> recipesList = recipeMap.getRecipeList()
                         .stream()
                         .filter(recipe -> !recipe.isHidden() && recipe.hasValidInputsForDisplay())
-                        .map(GTRecipeWrapper::new)
+                        .map(r -> new GTRecipeWrapper(recipeMap, r))
                         .collect(Collectors.toList());
                 registry.addRecipes(recipesList, GTValues.MODID + ":" + recipeMap.unlocalizedName);
             }

--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -2,6 +2,7 @@ package gregtech.integration.jei.recipe;
 
 import gregtech.api.recipes.Recipe;
 import gregtech.api.recipes.Recipe.ChanceEntry;
+import gregtech.api.recipes.RecipeMap;
 import gregtech.api.recipes.recipeproperties.PrimitiveProperty;
 import gregtech.api.recipes.recipeproperties.RecipeProperty;
 import gregtech.api.unification.OreDictUnifier;
@@ -26,9 +27,11 @@ public class GTRecipeWrapper implements IRecipeWrapper {
     private static final int LINE_HEIGHT = 10;
 
     private final Int2ObjectMap<ChanceEntry> chanceOutput = new Int2ObjectOpenHashMap<>();
+    private final RecipeMap<?> recipeMap;
     private final Recipe recipe;
 
-    public GTRecipeWrapper(Recipe recipe) {
+    public GTRecipeWrapper(RecipeMap<?> recipeMap, Recipe recipe) {
+        this.recipeMap = recipeMap;
         this.recipe = recipe;
     }
 
@@ -38,7 +41,7 @@ public class GTRecipeWrapper implements IRecipeWrapper {
 
     @Override
     public void getIngredients(@Nonnull IIngredients ingredients) {
-        int currentSlot = 0;
+        int currentSlot = recipeMap.getMaxInputs();
 
         // Inputs
         if (!recipe.getInputs().isEmpty()) {
@@ -48,7 +51,6 @@ public class GTRecipeWrapper implements IRecipeWrapper {
                     .map(is -> GTUtility.copyAmount(ci.getCount() == 0 ? 1 : ci.getCount(), is))
                     .collect(Collectors.toList())));
             ingredients.setInputLists(VanillaTypes.ITEM, matchingInputs);
-            currentSlot = recipe.getInputs().size();
         }
 
         // Fluid Inputs


### PR DESCRIPTION
**What:**
Fixes an issue with JEI chanced output display, visible on the sphaelerite electrolysis recipe

**Additional info:**
Re-adds RecipeMap to the GTRecipeWrapper constructor