### PR TITLE
add some more z to the chance text overlay

### DIFF
--- a/src/main/java/gregtech/integration/jei/utils/render/ItemStackChanceRenderer.java
+++ b/src/main/java/gregtech/integration/jei/utils/render/ItemStackChanceRenderer.java
@@ -25,7 +25,7 @@ public class ItemStackChanceRenderer extends ItemStackRenderer {
             GlStateManager.pushMatrix();
             GlStateManager.scale(0.5, 0.5, 1);
             // z hackery to render the text above the item
-            GlStateManager.translate(0, 0, 151);
+            GlStateManager.translate(0, 0, 160);
 
             String s = (this.chance.getChance() / 100) + "%";
             if (this.chance.getBoostPerTier() > 0)


### PR DESCRIPTION
**What:**
fixes this
![image](https://user-images.githubusercontent.com/66188216/137041361-87bc1838-2d9d-4f73-bc59-331d9f952540.png)


**How solved:**
text render at +160 z instead of +151