### PR TITLE
Expand data codes to constants

### DIFF
--- a/src/main/java/gregtech/api/capability/GregtechDataCodes.java
+++ b/src/main/java/gregtech/api/capability/GregtechDataCodes.java
@@ -1,0 +1,77 @@
+package gregtech.api.capability;
+
+public class GregtechDataCodes {
+
+    // MTE implementation update codes
+    public static final int INITIALIZE_MTE = -1;
+    public static final int UPDATE_FRONT_FACING = -2;
+    public static final int UPDATE_PAINTING_COLOR = -3;
+    public static final int SYNC_MTE_TRAITS = -4;
+    public static final int COVER_ATTACHED_MTE = -5;
+    public static final int COVER_REMOVED_MTE = -6;
+    public static final int UPDATE_COVER_DATA_MTE = -7;
+    public static final int UPDATE_IS_FRAGILE = -8;
+
+    public static final int UPDATE_OUTPUT_FACING = 100;
+    public static final int UPDATE_AUTO_OUTPUT_ITEMS = 101;
+    public static final int UPDATE_AUTO_OUTPUT_FLUIDS = 102;
+
+    // Drum
+    public static final int UPDATE_AUTO_OUTPUT = 560;
+    public static final int SYNC_FLUID_CONTENT = -200;
+    public static final int SYNC_FLUID_AMOUNT = -201;
+
+    // Safe
+    public static final int UPDATE_LOCKED_STATE = 8;
+    public static final int UPDATE_CONTENTS_SEED = 9;
+
+    // World Accelerator
+    public static final int SYNC_TILE_MODE = 100;
+    public static final int IS_ACTIVE = 1;
+
+    // Transformer
+    public static final int SYNC_TRANSFORM_STATE = 100;
+
+    // Clipboard
+    public static final int UPDATE_UI = 0;
+    public static final int CREATE_FAKE_UI = 1;
+    public static final int MOUSE_POSITION = 2;
+
+    // Pump
+    public static final int PUMP_HEAD_LEVEL = 200;
+
+    // Item Collector, Magic Energy Absorber, Large Boiler, Steam Oven
+    public static final int IS_WORKING = 100;
+
+    public static final int IS_BURNING = 100;
+
+    // Adjustable Transformer, Adjustable Energy Hatch, Diode
+    public static final int AMP_INDEX = 101;
+
+    // Pipe implementation update codes
+    public static final int UPDATE_INSULATION_COLOR = -1;
+    public static final int UPDATE_CONNECTIONS = -2;
+    public static final int SYNC_COVER_IMPLEMENTATION = -3;
+    public static final int UPDATE_PIPE_TYPE = -4;
+    public static final int UPDATE_PIPE_MATERIAL = -5;
+    public static final int UPDATE_COVER_DATA_PIPE = 0;
+    public static final int COVER_ATTACHED_PIPE = 1;
+    public static final int COVER_REMOVED_PIPE = 2;
+
+    // Multiblock implementation update codes
+    public static final int SYNC_CONTROLLER = 100;
+    public static final int IS_ROTOR_LOOPING = 200;
+    public static final int UPDATE_ROTOR_COLOR = 201;
+    public static final int STRUCTURE_FORMED = 400;
+    public static final int IS_TAPED = 550;
+    public static final int STORE_MAINTENANCE = 551;
+    public static final int STORE_TAPED = 552;
+    public static final int RECIPE_MAP_INDEX = 553;
+    public static final int IS_FRONT_FACE_FREE = 554;
+
+    // Multiblock Fluid Tank implementation update codes
+    public static final int UPDATE_CONTROLLER_POSITION = 1;
+    public static final int DEFORM_TANK = 2;
+    public static final int SYNC_FLUID_CHANGE = 3;
+    public static final int SYNC_TANK_SHAPE = 4;
+}

--- a/src/main/java/gregtech/api/capability/MultiblockDataCodes.java
+++ b/src/main/java/gregtech/api/capability/MultiblockDataCodes.java
@@ -1,9 +1,0 @@
-package gregtech.api.capability;
-
-public class MultiblockDataCodes {
-    public static final int IS_TAPED = 550;
-    public static final int STORE_MAINTENANCE = 551;
-    public static final int STORE_TAPED = 552;
-    public static final int RECIPE_MAP_INDEX = 553;
-    public static final int IS_FRONT_FACE_FREE = 554;
-}

--- a/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
+++ b/src/main/java/gregtech/api/metatileentity/MetaTileEntityHolder.java
@@ -22,6 +22,8 @@ import net.minecraftforge.common.util.Constants.NBT;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import static gregtech.api.capability.GregtechDataCodes.INITIALIZE_MTE;
+
 public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIHolder {
 
     private MetaTileEntity metaTileEntity;
@@ -47,7 +49,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
         this.metaTileEntity.onAttached();
         if (hasWorld() && !getWorld().isRemote) {
             updateBlockOpacity();
-            writeCustomData(-1, buffer -> {
+            writeCustomData(INITIALIZE_MTE, buffer -> {
                 buffer.writeVarInt(GregTechAPI.MTE_REGISTRY.getIdByObjectName(metaTileEntity.metaTileEntityId));
                 metaTileEntity.writeInitialSyncData(buffer);
             });
@@ -158,7 +160,7 @@ public class MetaTileEntityHolder extends TickableTileEntityBase implements IUIH
 
     @Override
     public void receiveCustomData(int discriminator, PacketBuffer buffer) {
-        if (discriminator == -1) {
+        if (discriminator == INITIALIZE_MTE) {
             int metaTileEntityId = buffer.readVarInt();
             setMetaTileEntity(GregTechAPI.MTE_REGISTRY.getObjectById(metaTileEntityId));
             this.metaTileEntity.receiveInitialSyncData(buffer);

--- a/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleMachineMetaTileEntity.java
@@ -41,6 +41,8 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.function.Function;
 
+import static gregtech.api.capability.GregtechDataCodes.*;
+
 public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity implements IActiveOutputSide {
 
     private final boolean hasFrontFacing;
@@ -254,14 +256,14 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacingItems = EnumFacing.VALUES[buf.readByte()];
             this.outputFacingFluids = EnumFacing.VALUES[buf.readByte()];
             getHolder().scheduleChunkForRenderUpdate();
-        } else if (dataId == 101) {
+        } else if (dataId == UPDATE_AUTO_OUTPUT_ITEMS) {
             this.autoOutputItems = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
-        } else if (dataId == 102) {
+        } else if (dataId == UPDATE_AUTO_OUTPUT_FLUIDS) {
             this.autoOutputFluids = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -280,7 +282,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         this.outputFacingFluids = outputFacing;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(100, buf -> {
+            writeCustomData(UPDATE_OUTPUT_FACING, buf -> {
                 buf.writeByte(outputFacingItems.getIndex());
                 buf.writeByte(outputFacingFluids.getIndex());
             });
@@ -292,7 +294,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         this.outputFacingItems = outputFacing;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(100, buf -> {
+            writeCustomData(UPDATE_OUTPUT_FACING, buf -> {
                 buf.writeByte(outputFacingItems.getIndex());
                 buf.writeByte(outputFacingFluids.getIndex());
             });
@@ -304,7 +306,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
         this.outputFacingFluids = outputFacing;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(100, buf -> {
+            writeCustomData(UPDATE_OUTPUT_FACING, buf -> {
                 buf.writeByte(outputFacingItems.getIndex());
                 buf.writeByte(outputFacingFluids.getIndex());
             });
@@ -315,7 +317,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     public void setAutoOutputItems(boolean autoOutputItems) {
         this.autoOutputItems = autoOutputItems;
         if (!getWorld().isRemote) {
-            writeCustomData(101, buf -> buf.writeBoolean(autoOutputItems));
+            writeCustomData(UPDATE_AUTO_OUTPUT_ITEMS, buf -> buf.writeBoolean(autoOutputItems));
             markDirty();
         }
     }
@@ -323,7 +325,7 @@ public class SimpleMachineMetaTileEntity extends WorkableTieredMetaTileEntity im
     public void setAutoOutputFluids(boolean autoOutputFluids) {
         this.autoOutputFluids = autoOutputFluids;
         if (!getWorld().isRemote) {
-            writeCustomData(102, buf -> buf.writeBoolean(autoOutputFluids));
+            writeCustomData(UPDATE_AUTO_OUTPUT_FLUIDS, buf -> buf.writeBoolean(autoOutputFluids));
             markDirty();
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockControllerBase.java
@@ -42,6 +42,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static gregtech.api.capability.GregtechDataCodes.STRUCTURE_FORMED;
+
 public abstract class MultiblockControllerBase extends MetaTileEntity implements IMultiblockController {
 
     public BlockPattern structurePattern;
@@ -222,7 +224,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
                 this.multiblockParts.addAll(parts);
                 this.multiblockAbilities.putAll(abilities);
                 this.structureFormed = true;
-                writeCustomData(400, buf -> buf.writeBoolean(true));
+                writeCustomData(STRUCTURE_FORMED, buf -> buf.writeBoolean(true));
                 formStructure(context);
             }
         } else if (context == null && structureFormed) {
@@ -238,7 +240,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
         this.multiblockAbilities.clear();
         this.multiblockParts.clear();
         this.structureFormed = false;
-        writeCustomData(400, buf -> buf.writeBoolean(false));
+        writeCustomData(STRUCTURE_FORMED, buf -> buf.writeBoolean(false));
     }
 
     @Override
@@ -274,7 +276,7 @@ public abstract class MultiblockControllerBase extends MetaTileEntity implements
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 400) {
+        if (dataId == STRUCTURE_FORMED) {
             this.structureFormed = buf.readBoolean();
         }
     }

--- a/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/MultiblockWithDisplayBase.java
@@ -35,7 +35,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import java.util.*;
 import java.util.function.Predicate;
 
-import static gregtech.api.capability.MultiblockDataCodes.STORE_TAPED;
+import static gregtech.api.capability.GregtechDataCodes.STORE_TAPED;
 
 public abstract class MultiblockWithDisplayBase extends MultiblockControllerBase implements IMaintenance {
 

--- a/src/main/java/gregtech/api/pipenet/block/material/TileEntityMaterialPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/block/material/TileEntityMaterialPipeBase.java
@@ -10,6 +10,8 @@ import gregtech.api.unification.material.Materials;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.PacketBuffer;
 
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_PIPE_MATERIAL;
+
 public abstract class TileEntityMaterialPipeBase<PipeType extends Enum<PipeType> & IPipeType<NodeDataType>, NodeDataType> extends TileEntityPipeBase<PipeType, NodeDataType> implements IMaterialPipeTile<PipeType, NodeDataType> {
 
     private Material pipeMaterial = Materials.Aluminium;
@@ -23,7 +25,7 @@ public abstract class TileEntityMaterialPipeBase<PipeType extends Enum<PipeType>
         super.setPipeData(pipeBlock, pipeType);
         this.pipeMaterial = pipeMaterial;
         if (!getWorld().isRemote) {
-            writeCustomData(-5, this::writePipeMaterial);
+            writeCustomData(UPDATE_PIPE_MATERIAL, this::writePipeMaterial);
         }
     }
 
@@ -74,7 +76,7 @@ public abstract class TileEntityMaterialPipeBase<PipeType extends Enum<PipeType>
     @Override
     public void receiveCustomData(int discriminator, PacketBuffer buf) {
         super.receiveCustomData(discriminator, buf);
-        if (discriminator == -5) {
+        if (discriminator == UPDATE_PIPE_MATERIAL) {
             readPipeMaterial(buf);
             scheduleChunkForRenderUpdate();
         }

--- a/src/main/java/gregtech/common/gui/impl/FakeModularUIContainerClipboard.java
+++ b/src/main/java/gregtech/common/gui/impl/FakeModularUIContainerClipboard.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_UI;
+
 
 // Note: when porting the central monitor, please make this more generic.
 public class FakeModularUIContainerClipboard implements WidgetUIAccess {
@@ -117,7 +119,7 @@ public class FakeModularUIContainerClipboard implements WidgetUIAccess {
 
     @Override
     public void writeUpdateInfo(Widget widget, int updateId, Consumer<PacketBuffer> payloadWriter) {
-        this.clipboard.writeCustomData(0, buf -> {
+        this.clipboard.writeCustomData(UPDATE_UI, buf -> {
             buf.writeVarInt(windowId);
             buf.writeVarInt(modularUI.guiWidgets.inverse().get(widget));
             buf.writeVarInt(updateId);

--- a/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
+++ b/src/main/java/gregtech/common/metatileentities/MetaTileEntityClipboard.java
@@ -21,7 +21,6 @@ import gregtech.api.util.GregFakePlayer;
 import gregtech.common.gui.impl.FakeModularUIContainerClipboard;
 import gregtech.common.items.behaviors.ClipboardBehavior;
 import net.minecraft.block.Block;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
@@ -38,8 +37,6 @@ import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.relauncher.Side;
-import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.commons.lang3.tuple.Pair;
 
 import javax.annotation.Nullable;
@@ -48,6 +45,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static codechicken.lib.raytracer.RayTracer.*;
+import static gregtech.api.capability.GregtechDataCodes.*;
 import static gregtech.api.render.Textures.CLIPBOARD_RENDERER;
 import static gregtech.common.items.MetaItems.CLIPBOARD;
 
@@ -158,7 +156,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IRenderMe
             FakeModularUIContainerClipboard fakeModularUIContainer = new FakeModularUIContainerClipboard(ui, this);
             this.guiContainerCache = fakeModularUIContainer;
             this.guiCache = new FakeModularGui(ui, fakeModularUIContainer);
-            this.writeCustomData(1, buffer -> { });
+            this.writeCustomData(CREATE_FAKE_UI, buffer -> { });
         } catch (Exception e) {
             GTLog.logger.error(e);
         }
@@ -343,16 +341,16 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IRenderMe
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 0) {
+        if (dataId == UPDATE_UI) {
             int windowID = buf.readVarInt();
             int widgetID = buf.readVarInt();
             if (guiCache != null)
                 guiCache.handleWidgetUpdate(windowID, widgetID, buf);
             this.scheduleRenderUpdate();
-        } else if (dataId == 1) {
+        } else if (dataId == CREATE_FAKE_UI) {
             createFakeGui();
             this.scheduleRenderUpdate();
-        } else if (dataId == 2) {
+        } else if (dataId == MOUSE_POSITION) {
             int mouseX = buf.readVarInt();
             int mouseY = buf.readVarInt();
             if (guiCache != null && guiContainerCache != null) {
@@ -395,7 +393,7 @@ public class MetaTileEntityClipboard extends MetaTileEntity implements IRenderMe
             int mouseX = (int) ((clickCoords.getLeft() / scale));
             int mouseY = (int) ((clickCoords.getRight() / scale));
             if (0 <= mouseX && mouseX <= width && 0 <= mouseY && mouseY <= height) {
-                this.writeCustomData(2, buf -> {
+                this.writeCustomData(MOUSE_POSITION, buf -> {
                     buf.writeVarInt(mouseX);
                     buf.writeVarInt(mouseY);
                 });

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAdjustableTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityAdjustableTransformer.java
@@ -29,6 +29,8 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.AMP_INDEX;
+
 public class MetaTileEntityAdjustableTransformer extends MetaTileEntityTransformer {
 
     private static final int[] hiAmpsRange = {1, 2, 4, 16};
@@ -74,7 +76,7 @@ public class MetaTileEntityAdjustableTransformer extends MetaTileEntityTransform
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 101) {
+        if (dataId == AMP_INDEX) {
             this.ampIndex = buf.readInt();
             scheduleRenderUpdate();
         }
@@ -84,7 +86,7 @@ public class MetaTileEntityAdjustableTransformer extends MetaTileEntityTransform
         this.ampIndex = (this.ampIndex + 1) % hiAmpsRange.length;
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
-            writeCustomData(101, b -> b.writeInt(ampIndex));
+            writeCustomData(AMP_INDEX, b -> b.writeInt(ampIndex));
             getHolder().notifyBlockUpdate();
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityBlockBreaker.java
@@ -41,6 +41,8 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_OUTPUT_FACING;
+
 public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
 
     private EnumFacing outputFacing;
@@ -178,7 +180,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacing = EnumFacing.VALUES[buf.readByte()];
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -199,7 +201,7 @@ public class MetaTileEntityBlockBreaker extends TieredMetaTileEntity {
         this.outputFacing = outputFacing;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(100, buf -> buf.writeByte(outputFacing.getIndex()));
+            writeCustomData(UPDATE_OUTPUT_FACING, buf -> buf.writeByte(outputFacing.getIndex()));
             markDirty();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityDiode.java
@@ -30,6 +30,8 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.AMP_INDEX;
+
 public class MetaTileEntityDiode extends TieredMetaTileEntity {
 
     private static final String AMP_NBT_KEY = "amp_mode";
@@ -75,7 +77,7 @@ public class MetaTileEntityDiode extends TieredMetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 101) {
+        if (dataId == AMP_INDEX) {
             this.amps = buf.readInt();
         }
     }
@@ -84,7 +86,7 @@ public class MetaTileEntityDiode extends TieredMetaTileEntity {
         amps = amps == 16 ? 1 : amps << 1;
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
-            writeCustomData(101, b -> b.writeInt(amps));
+            writeCustomData(AMP_INDEX, b -> b.writeInt(amps));
             getHolder().notifyBlockUpdate();
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityItemCollector.java
@@ -39,6 +39,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
+
 public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
 
     private static final int[] INVENTORY_SIZES = {4, 9, 16, 25, 25};
@@ -93,7 +95,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == IS_WORKING) {
             this.isWorking = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -127,7 +129,7 @@ public class MetaTileEntityItemCollector extends TieredMetaTileEntity {
 
         if (isWorkingNow != isWorking) {
             this.isWorking = isWorkingNow;
-            writeCustomData(100, buffer -> buffer.writeBoolean(isWorkingNow));
+            writeCustomData(IS_WORKING, buffer -> buffer.writeBoolean(isWorkingNow));
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityMagicEnergyAbsorber.java
@@ -40,6 +40,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
+
 public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
 
     private final TIntList connectedCrystalsIds = new TIntArrayList();
@@ -104,7 +106,7 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
         if (this.isActive != isActive) {
             this.isActive = isActive;
             if (!getWorld().isRemote) {
-                writeCustomData(100, w -> w.writeBoolean(isActive));
+                writeCustomData(IS_WORKING, w -> w.writeBoolean(isActive));
             }
         }
     }
@@ -112,7 +114,7 @@ public class MetaTileEntityMagicEnergyAbsorber extends TieredMetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == IS_WORKING) {
             this.isActive = buf.readBoolean();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityPump.java
@@ -48,6 +48,8 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.PUMP_HEAD_LEVEL;
+
 public class MetaTileEntityPump extends TieredMetaTileEntity {
 
     private static final Cuboid6 PIPE_CUBOID = new Cuboid6(6 / 16.0, 0.0, 6 / 16.0, 10 / 16.0, 1.0, 10 / 16.0);
@@ -101,7 +103,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 200) {
+        if (dataId == PUMP_HEAD_LEVEL) {
             this.pumpHeadY = buf.readVarInt();
             scheduleRenderUpdate();
         }
@@ -193,7 +195,7 @@ public class MetaTileEntityPump extends TieredMetaTileEntity {
                 }
 
                 // Always recheck next time
-                writeCustomData(200, b -> b.writeVarInt(pumpHeadY));
+                writeCustomData(PUMP_HEAD_LEVEL, b -> b.writeVarInt(pumpHeadY));
                 markDirty();
                 //schedule queue rebuild because we changed our position and no fluid is available
                 this.initializedQueue = false;

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTransformer.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityTransformer.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.SYNC_TRANSFORM_STATE;
+
 public class MetaTileEntityTransformer extends TieredMetaTileEntity {
 
     private boolean isTransformUp;
@@ -73,7 +75,7 @@ public class MetaTileEntityTransformer extends TieredMetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == SYNC_TRANSFORM_STATE) {
             this.isTransformUp = buf.readBoolean();
             scheduleRenderUpdate();
         }
@@ -87,7 +89,7 @@ public class MetaTileEntityTransformer extends TieredMetaTileEntity {
         isTransformUp = inverted;
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
-            writeCustomData(100, b -> b.writeBoolean(isTransformUp));
+            writeCustomData(SYNC_TRANSFORM_STATE, b -> b.writeBoolean(isTransformUp));
             getHolder().notifyBlockUpdate();
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
@@ -35,6 +35,9 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.IntStream;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_ACTIVE;
+import static gregtech.api.capability.GregtechDataCodes.SYNC_TILE_MODE;
+
 public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity implements IControllable {
 
     private static Class<?> clazz;
@@ -177,7 +180,7 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
         tileMode = inverted;
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
-            writeCustomData(100, b -> b.writeBoolean(tileMode));
+            writeCustomData(SYNC_TILE_MODE, b -> b.writeBoolean(tileMode));
             getHolder().notifyBlockUpdate();
             markDirty();
         }
@@ -219,11 +222,11 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 1) {
+        if (dataId == IS_ACTIVE) {
             this.isActive = buf.readBoolean();
             scheduleRenderUpdate();
         }
-        if (dataId == 100) {
+        if (dataId == SYNC_TILE_MODE) {
             this.tileMode = buf.readBoolean();
             scheduleRenderUpdate();
         }
@@ -233,7 +236,7 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
         this.isActive = active;
         markDirty();
         if (!getWorld().isRemote) {
-            writeCustomData(1, buf -> buf.writeBoolean(active));
+            writeCustomData(IS_ACTIVE, buf -> buf.writeBoolean(active));
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityAdjustableEnergyHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityAdjustableEnergyHatch.java
@@ -29,6 +29,8 @@ import net.minecraft.world.World;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.AMP_INDEX;
+
 public class MetaTileEntityAdjustableEnergyHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IEnergyContainer> {
 
     private static final int[] ampRange = {2, 4, 8, 16};
@@ -107,7 +109,7 @@ public class MetaTileEntityAdjustableEnergyHatch extends MetaTileEntityMultibloc
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 101) {
+        if (dataId == AMP_INDEX) {
             this.ampIndex = buf.readInt();
             scheduleRenderUpdate();
         }
@@ -117,7 +119,7 @@ public class MetaTileEntityAdjustableEnergyHatch extends MetaTileEntityMultibloc
         this.ampIndex = (this.ampIndex + 1) % ampRange.length;
         if (!getWorld().isRemote) {
             reinitializeEnergyContainer();
-            writeCustomData(101, b -> b.writeInt(ampIndex));
+            writeCustomData(AMP_INDEX, b -> b.writeInt(ampIndex));
             getHolder().notifyBlockUpdate();
             markDirty();
         }

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMaintenanceHatch.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMaintenanceHatch.java
@@ -32,8 +32,8 @@ import net.minecraftforge.items.ItemStackHandler;
 import javax.annotation.Nullable;
 import java.util.List;
 
-import static gregtech.api.capability.MultiblockDataCodes.IS_TAPED;
-import static gregtech.api.capability.MultiblockDataCodes.STORE_MAINTENANCE;
+import static gregtech.api.capability.GregtechDataCodes.IS_TAPED;
+import static gregtech.api.capability.GregtechDataCodes.STORE_MAINTENANCE;
 
 public class MetaTileEntityMaintenanceHatch extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<IMaintenanceHatch>, IMaintenanceHatch {
 

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMultiblockPart.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityMultiblockPart.java
@@ -20,6 +20,8 @@ import net.minecraft.util.math.BlockPos;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
+import static gregtech.api.capability.GregtechDataCodes.SYNC_CONTROLLER;
+
 public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity implements IMultiblockPart, ITieredMetaTileEntity {
 
     private final int tier;
@@ -117,7 +119,7 @@ public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity implem
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == SYNC_CONTROLLER) {
             if (buf.readBoolean()) {
                 this.controllerPos = buf.readBlockPos();
                 this.controllerTile = null;
@@ -132,7 +134,7 @@ public abstract class MetaTileEntityMultiblockPart extends MetaTileEntity implem
     private void setController(MultiblockControllerBase controller1) {
         this.controllerTile = controller1;
         if (!getWorld().isRemote) {
-            writeCustomData(100, writer -> {
+            writeCustomData(SYNC_CONTROLLER, writer -> {
                 writer.writeBoolean(controllerTile != null);
                 if (controllerTile != null) {
                     writer.writeBlockPos(controllerTile.getPos());

--- a/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/multiblockpart/MetaTileEntityRotorHolder.java
@@ -37,6 +37,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_ROTOR_LOOPING;
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_ROTOR_COLOR;
+
 public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart implements IMultiblockAbilityPart<MetaTileEntityRotorHolder> {
 
     private static final int NORMAL_MAXIMUM_SPEED = 6000;
@@ -195,7 +198,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         this.currentRotorSpeed = MathHelper.clamp(currentRotorSpeed + incrementSpeed, 0, maxRotorSpeed);
         this.isRotorLooping = currentRotorSpeed > 0;
         if (isRotorLooping != lastIsLooping && !getWorld().isRemote) {
-            writeCustomData(200, writer -> writer.writeBoolean(isRotorLooping));
+            writeCustomData(IS_ROTOR_LOOPING, writer -> writer.writeBoolean(isRotorLooping));
             markDirty();
         }
     }
@@ -204,7 +207,7 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
         int lastHasRotor = rotorColor;
         this.rotorColor = hasRotor1;
         if (rotorColor != lastHasRotor && (getWorld() != null && !getWorld().isRemote)) {
-            writeCustomData(201, writer -> writer.writeInt(rotorColor));
+            writeCustomData(UPDATE_ROTOR_COLOR, writer -> writer.writeInt(rotorColor));
             markDirty();
         }
     }
@@ -212,10 +215,10 @@ public class MetaTileEntityRotorHolder extends MetaTileEntityMultiblockPart impl
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 200) {
+        if (dataId == IS_ROTOR_LOOPING) {
             this.isRotorLooping = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
-        } else if (dataId == 201) {
+        } else if (dataId == UPDATE_ROTOR_COLOR) {
             this.rotorColor = buf.readInt();
             getHolder().scheduleChunkForRenderUpdate();
         }

--- a/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/MetaTileEntityLargeBoiler.java
@@ -55,6 +55,7 @@ import net.minecraftforge.fluids.IFluidTank;
 import javax.annotation.Nonnull;
 import java.util.*;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
 import static gregtech.api.gui.widgets.AdvancedTextWidget.withButton;
 import static gregtech.api.gui.widgets.AdvancedTextWidget.withHoverTextTranslate;
 
@@ -344,7 +345,7 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
             if (isStructureFormed()) {
                 replaceFireboxAsActive(active);
             }
-            writeCustomData(100, buf -> buf.writeBoolean(isActive));
+            writeCustomData(IS_WORKING, buf -> buf.writeBoolean(isActive));
             markDirty();
         }
     }
@@ -391,7 +392,7 @@ public class MetaTileEntityLargeBoiler extends MultiblockWithDisplayBase impleme
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == IS_WORKING) {
             this.isActive = buf.readBoolean();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/steam/MetaTileEntitySteamOven.java
@@ -25,6 +25,8 @@ import net.minecraft.util.math.BlockPos;
 
 import javax.annotation.Nonnull;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_WORKING;
+
 public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController {
 
     private boolean isActive;
@@ -45,7 +47,7 @@ public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController 
             if (isStructureFormed()) {
                 replaceFireboxAsActive(active);
             }
-            writeCustomData(100, buf -> buf.writeBoolean(isActive));
+            writeCustomData(IS_WORKING, buf -> buf.writeBoolean(isActive));
             markDirty();
         }
     }
@@ -163,7 +165,7 @@ public class MetaTileEntitySteamOven extends RecipeMapSteamMultiblockController 
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == IS_WORKING) {
             this.isActive = buf.readBoolean();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/boiler/SteamBoiler.java
@@ -37,6 +37,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.IS_BURNING;
+
 public abstract class SteamBoiler extends MetaTileEntity {
 
     private static final EnumFacing[] STEAM_PUSH_DIRECTIONS = ArrayUtils.add(EnumFacing.HORIZONTALS, EnumFacing.UP);
@@ -132,7 +134,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == IS_BURNING) {
             this.isBurning = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -228,7 +230,7 @@ public abstract class SteamBoiler extends MetaTileEntity {
         this.isBurning = burning;
         if (!getWorld().isRemote) {
             markDirty();
-            writeCustomData(100, buf -> buf.writeBoolean(burning));
+            writeCustomData(IS_BURNING, buf -> buf.writeBoolean(burning));
         }
     }
 

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityDrum.java
@@ -43,6 +43,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.*;
 import static gregtech.api.unification.material.info.MaterialFlags.FLAMMABLE;
 
 public class MetaTileEntityDrum extends MetaTileEntity {
@@ -186,7 +187,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == -200) {
+        if (dataId == SYNC_FLUID_CONTENT) {
             FluidStack fluidStack = null;
             if (buf.readBoolean()) {
                 try {
@@ -196,7 +197,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
                 }
             }
             fluidTank.setFluid(fluidStack);
-        } else if (dataId == 560) {
+        } else if (dataId == UPDATE_AUTO_OUTPUT) {
             this.isAutoOutput = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -235,7 +236,7 @@ public class MetaTileEntityDrum extends MetaTileEntity {
         isAutoOutput = !isAutoOutput;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(560, buf -> buf.writeBoolean(isAutoOutput));
+            writeCustomData(UPDATE_AUTO_OUTPUT, buf -> buf.writeBoolean(isAutoOutput));
             markDirty();
         }
     }
@@ -330,9 +331,9 @@ public class MetaTileEntityDrum extends MetaTileEntity {
         private void onContentsChangedOnServer(FluidStack newFluid, FluidStack oldFluidStack) {
 
             if (newFluid != null && newFluid.isFluidEqual(oldFluidStack)) {
-                writeCustomData(-201, buf -> buf.writeInt(newFluid.amount));
+                writeCustomData(SYNC_FLUID_AMOUNT, buf -> buf.writeInt(newFluid.amount));
             } else {
-                writeCustomData(-200, buf -> {
+                writeCustomData(SYNC_FLUID_CONTENT, buf -> {
                     buf.writeBoolean(newFluid != null);
                     if (newFluid != null) {
                         NBTTagCompound tagCompound = new NBTTagCompound();

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityLockedSafe.java
@@ -51,6 +51,9 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.DoubleSupplier;
 
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_CONTENTS_SEED;
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_LOCKED_STATE;
+
 public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRenderMetaTileEntity {
 
     private static final int MAX_UNLOCK_PROGRESS = 100;
@@ -268,7 +271,7 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
     public void setSafeUnlocked(boolean safeUnlocked) {
         this.isSafeUnlocked = safeUnlocked;
         if (getWorld() != null && !getWorld().isRemote) {
-            writeCustomData(8, buf -> buf.writeBoolean(safeUnlocked));
+            writeCustomData(UPDATE_LOCKED_STATE, buf -> buf.writeBoolean(safeUnlocked));
             getHolder().notifyBlockUpdate();
             markDirty();
         }
@@ -278,7 +281,7 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
         this.unlockComponentsSeed = unlockComponentsSeed;
         if (getWorld() != null && !getWorld().isRemote) {
             updateDisplayUnlockComponents();
-            writeCustomData(9, buf -> buf.writeVarLong(unlockComponentsSeed));
+            writeCustomData(UPDATE_CONTENTS_SEED, buf -> buf.writeVarLong(unlockComponentsSeed));
             markDirty();
         }
     }
@@ -305,9 +308,9 @@ public class MetaTileEntityLockedSafe extends MetaTileEntity implements IFastRen
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 8) {
+        if (dataId == UPDATE_LOCKED_STATE) {
             this.isSafeUnlocked = buf.readBoolean();
-        } else if (dataId == 9) {
+        } else if (dataId == UPDATE_CONTENTS_SEED) {
             this.unlockComponentsSeed = buf.readVarLong();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumChest.java
@@ -48,6 +48,9 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_AUTO_OUTPUT_ITEMS;
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_OUTPUT_FACING;
+
 public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITieredMetaTileEntity, IActiveOutputSide {
 
 
@@ -282,7 +285,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
         this.outputFacing = outputFacing;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(100, buf -> buf.writeByte(outputFacing.getIndex()));
+            writeCustomData(UPDATE_OUTPUT_FACING, buf -> buf.writeByte(outputFacing.getIndex()));
             markDirty();
         }
     }
@@ -325,10 +328,10 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacing = EnumFacing.VALUES[buf.readByte()];
             getHolder().scheduleChunkForRenderUpdate();
-        } else if (dataId == 101) {
+        } else if (dataId == UPDATE_AUTO_OUTPUT_ITEMS) {
             this.autoOutputItems = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -337,7 +340,7 @@ public class MetaTileEntityQuantumChest extends MetaTileEntity implements ITiere
     public void setAutoOutputItems(boolean autoOutputItems) {
         this.autoOutputItems = autoOutputItems;
         if (!getWorld().isRemote) {
-            writeCustomData(101, buf -> buf.writeBoolean(autoOutputItems));
+            writeCustomData(UPDATE_AUTO_OUTPUT_ITEMS, buf -> buf.writeBoolean(autoOutputItems));
             markDirty();
         }
     }

--- a/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
+++ b/src/main/java/gregtech/common/metatileentities/storage/MetaTileEntityQuantumTank.java
@@ -45,6 +45,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_AUTO_OUTPUT_FLUIDS;
+import static gregtech.api.capability.GregtechDataCodes.UPDATE_OUTPUT_FACING;
+
 public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITieredMetaTileEntity, IActiveOutputSide {
 
 
@@ -255,10 +258,10 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     @Override
     public void receiveCustomData(int dataId, PacketBuffer buf) {
         super.receiveCustomData(dataId, buf);
-        if (dataId == 100) {
+        if (dataId == UPDATE_OUTPUT_FACING) {
             this.outputFacing = EnumFacing.VALUES[buf.readByte()];
             getHolder().scheduleChunkForRenderUpdate();
-        } else if (dataId == 102) {
+        } else if (dataId == UPDATE_AUTO_OUTPUT_FLUIDS) {
             this.autoOutputFluids = buf.readBoolean();
             getHolder().scheduleChunkForRenderUpdate();
         }
@@ -280,7 +283,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
         this.outputFacing = outputFacing;
         if (!getWorld().isRemote) {
             getHolder().notifyBlockUpdate();
-            writeCustomData(100, buf -> buf.writeByte(outputFacing.getIndex()));
+            writeCustomData(UPDATE_OUTPUT_FACING, buf -> buf.writeByte(outputFacing.getIndex()));
             markDirty();
         }
     }
@@ -346,7 +349,7 @@ public class MetaTileEntityQuantumTank extends MetaTileEntity implements ITiered
     public void setAutoOutputFluids(boolean autoOutputFluids) {
         this.autoOutputFluids = autoOutputFluids;
         if (!getWorld().isRemote) {
-            writeCustomData(102, buf -> buf.writeBoolean(autoOutputFluids));
+            writeCustomData(UPDATE_AUTO_OUTPUT_FLUIDS, buf -> buf.writeBoolean(autoOutputFluids));
             markDirty();
         }
     }


### PR DESCRIPTION
**What:**
Moves custom sync data codes into constants, so that they can easily be referenced for what they do.

Currently this PR just translates the data code numerical values exactly from what they were in code, there could be several that could be consolidated into a single code, although I am not sure if there would be any consequences for this.

Also if anyone wants to suggest some names, feel free.

**Outcome:**
Makes constants out of the data codes used for custom sync data. Closes #174 