### PR TITLE
fix slot grid when the amount of slots is a prime number

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -396,6 +396,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         for (int i = 0; i < itemSlotsToDown; i++) {
             for (int j = 0; j < itemSlotsToLeft; j++) {
                 int slotIndex = i * itemSlotsToLeft + j;
+                if (slotIndex >= itemInputsCount) break;
                 int x = startInputsX + 18 * j;
                 int y = startInputsY + 18 * i;
                 addSlot(builder, x, y, slotIndex, itemHandler, fluidHandler, invertFluids, isOutputs);
@@ -453,7 +454,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         //return it.
         if (sqrt % 1 == 0) {
             itemSlotsToLeft = itemSlotsToDown = (int) sqrt;
-        } else {
+        } else if (itemInputsCount == 3) {
+            itemSlotsToLeft = 3;
+            itemSlotsToDown = 1;
+        }
+        else {
             //if we couldn't fit all into a perfect square,
             //increase the amount of slots to the left
             itemSlotsToLeft = (int) Math.ceil(sqrt);


### PR DESCRIPTION
**What:**
This PR solves the issue of `determineSlotsGrid` not taking into account that some numbers are not perfect squares or multiples of 2,3 , like prime numbers

**How solved:**
if the amount of input slots is not a perfect square, we raise the amount of slots to the left, if the total amount slots is still not enough we increase the amount of the bottom ( we grow the grid to the next perfect square root)

**Outcome:**
Returns a grid with appropriate slots for inputs with size 5,7,11.. etc

**Possible compatibility issue:**
None