### PR TITLE
Fix some failing tests and switch to more general method

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/MultiblockRecipeLogic.java
@@ -180,7 +180,7 @@ public class MultiblockRecipeLogic extends AbstractRecipeLogic {
         int numMaintenanceProblems = displayBase == null ? 0 : displayBase.getNumMaintenanceProblems();
 
         int[] overclock = null;
-        if (displayBase != null && ConfigHolder.U.GT5u.enableMaintenance) {
+        if (displayBase != null && displayBase.hasMaintenanceMechanics()) {
             IMaintenanceHatch hatch = displayBase.getAbilities(MultiblockAbility.MAINTENANCE_HATCH).get(0);
             double durationMultiplier = hatch.getDurationMultiplier();
             if (durationMultiplier != 1.0) {

--- a/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/multi/electric/MetaTileEntityElectricBlastFurnace.java
@@ -199,7 +199,7 @@ public class MetaTileEntityElectricBlastFurnace extends RecipeMapMultiblockContr
             double resultDuration = duration;
             MultiblockWithDisplayBase displayBase = (MultiblockWithDisplayBase) metaTileEntity;
             int numMaintenanceProblems = ((MultiblockWithDisplayBase) metaTileEntity).getNumMaintenanceProblems();
-            if (ConfigHolder.U.GT5u.enableMaintenance) {
+            if (((MetaTileEntityElectricBlastFurnace) metaTileEntity).hasMaintenanceMechanics()) {
                 IMaintenanceHatch hatch = displayBase.getAbilities(MultiblockAbility.MAINTENANCE_HATCH).get(0);
                 if (hatch.getDurationMultiplier() != 1.0) {
                     resultDuration *= hatch.getDurationMultiplier();


### PR DESCRIPTION
**What:**
This PR fixes some tests failing, and switches to the more general `hasMaintenanceProblems()` instead of checking the config directly.

The tests were failing because the initialization of the MTE in the tests overrode `hasMaintenanceProblems()`, but the checks in code were directly checking the config instead of the method.

**Outcome:**
Fixes some tests