### PR TITLE
Add Progress Bars that direct Players to JEI Page

### DIFF
--- a/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
@@ -1,5 +1,6 @@
 package gregtech.api.gui.widgets;
 
+import gregtech.api.GTValues;
 import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.recipes.RecipeMap;
 import gregtech.integration.jei.GTJeiPlugin;
@@ -11,7 +12,7 @@ import java.util.Collections;
 import java.util.function.DoubleSupplier;
 
 public class RecipeProgressWidget extends ProgressWidget {
-    private RecipeMap<?> recipeMap;
+    private final RecipeMap<?> recipeMap;
     private final static int HOVER_TEXT_WIDTH = 200;
 
     public RecipeProgressWidget(DoubleSupplier progressSupplier, int x, int y, int width, int height, RecipeMap<?> recipeMap) {
@@ -38,7 +39,7 @@ public class RecipeProgressWidget extends ProgressWidget {
     @Override
     public void drawInForeground(int mouseX, int mouseY) {
         super.drawInForeground(mouseX, mouseY);
-        if (isMouseOverElement(mouseX, mouseY)) {
+        if (isMouseOverElement(mouseX, mouseY) && GTValues.isModLoaded(GTValues.MODID_JEI)) {
             Minecraft mc = Minecraft.getMinecraft();
             GuiUtils.drawHoveringText(Collections.singletonList("Show Recipes"), mouseX, mouseY,
                     sizes.getScreenWidth(),

--- a/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
@@ -27,14 +27,12 @@ public class RecipeProgressWidget extends ProgressWidget {
 
     @Override
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
-        try {
-            Class.forName("gregtech.integration.jei.recipe.RecipeMapCategory");
-            if (isMouseOverElement(mouseX, mouseY) && RecipeMapCategory.getCategoryMap().containsKey(recipeMap)) {
-                // Since categories were even registered at all, we know JEI is active.
-                GTJeiPlugin.jeiRuntime.getRecipesGui().showCategories(Collections.singletonList(RecipeMapCategory.getCategoryMap().get(recipeMap).getUid()));
-                return true;
-            }
-        } catch (ClassNotFoundException ignored) {
+        if (!GTValues.isModLoaded(GTValues.MODID_JEI))
+            return false;
+        if (isMouseOverElement(mouseX, mouseY) && RecipeMapCategory.getCategoryMap().containsKey(recipeMap)) {
+            // Since categories were even registered at all, we know JEI is active.
+            GTJeiPlugin.jeiRuntime.getRecipesGui().showCategories(Collections.singletonList(RecipeMapCategory.getCategoryMap().get(recipeMap).getUid()));
+            return true;
         }
         return false;
     }

--- a/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
@@ -27,10 +27,14 @@ public class RecipeProgressWidget extends ProgressWidget {
 
     @Override
     public boolean mouseClicked(int mouseX, int mouseY, int button) {
-        if (isMouseOverElement(mouseX, mouseY) && RecipeMapCategory.getCategoryMap().containsKey(recipeMap)) {
-            // Since categories were even registered at all, we know JEI is active.
-            GTJeiPlugin.jeiRuntime.getRecipesGui().showCategories(Collections.singletonList(RecipeMapCategory.getCategoryMap().get(recipeMap).getUid()));
-            return true;
+        try {
+            Class.forName("gregtech.integration.jei.recipe.RecipeMapCategory");
+            if (isMouseOverElement(mouseX, mouseY) && RecipeMapCategory.getCategoryMap().containsKey(recipeMap)) {
+                // Since categories were even registered at all, we know JEI is active.
+                GTJeiPlugin.jeiRuntime.getRecipesGui().showCategories(Collections.singletonList(RecipeMapCategory.getCategoryMap().get(recipeMap).getUid()));
+                return true;
+            }
+        } catch (ClassNotFoundException ignored) {
         }
         return false;
     }

--- a/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
+++ b/src/main/java/gregtech/api/gui/widgets/RecipeProgressWidget.java
@@ -1,0 +1,49 @@
+package gregtech.api.gui.widgets;
+
+import gregtech.api.gui.resources.TextureArea;
+import gregtech.api.recipes.RecipeMap;
+import gregtech.integration.jei.GTJeiPlugin;
+import gregtech.integration.jei.recipe.RecipeMapCategory;
+import net.minecraft.client.Minecraft;
+import net.minecraftforge.fml.client.config.GuiUtils;
+
+import java.util.Collections;
+import java.util.function.DoubleSupplier;
+
+public class RecipeProgressWidget extends ProgressWidget {
+    private RecipeMap<?> recipeMap;
+    private final static int HOVER_TEXT_WIDTH = 200;
+
+    public RecipeProgressWidget(DoubleSupplier progressSupplier, int x, int y, int width, int height, RecipeMap<?> recipeMap) {
+        super(progressSupplier, x, y, width, height);
+        this.recipeMap = recipeMap;
+    }
+
+    public RecipeProgressWidget(DoubleSupplier progressSupplier, int x, int y, int width, int height, TextureArea fullImage, MoveType moveType, RecipeMap<?> recipeMap) {
+        super(progressSupplier, x, y, width, height, fullImage, moveType);
+        this.recipeMap = recipeMap;
+    }
+
+    @Override
+    public boolean mouseClicked(int mouseX, int mouseY, int button) {
+        if (isMouseOverElement(mouseX, mouseY) && RecipeMapCategory.getCategoryMap().containsKey(recipeMap)) {
+            // Since categories were even registered at all, we know JEI is active.
+            GTJeiPlugin.jeiRuntime.getRecipesGui().showCategories(Collections.singletonList(RecipeMapCategory.getCategoryMap().get(recipeMap).getUid()));
+            return true;
+        }
+        return false;
+    }
+
+
+    @Override
+    public void drawInForeground(int mouseX, int mouseY) {
+        super.drawInForeground(mouseX, mouseY);
+        if (isMouseOverElement(mouseX, mouseY)) {
+            Minecraft mc = Minecraft.getMinecraft();
+            GuiUtils.drawHoveringText(Collections.singletonList("Show Recipes"), mouseX, mouseY,
+                    sizes.getScreenWidth(),
+                    sizes.getScreenHeight(), HOVER_TEXT_WIDTH, mc.fontRenderer);
+        }
+    }
+
+}

--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -15,6 +15,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.gui.widgets.TankWidget;
 import gregtech.api.recipes.builders.IntCircuitRecipeBuilder;
@@ -367,7 +368,7 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
     //this DOES NOT include machine control widgets or binds player inventory
     public ModularUI.Builder createUITemplate(DoubleSupplier progressSupplier, IItemHandlerModifiable importItems, IItemHandlerModifiable exportItems, FluidTankList importFluids, FluidTankList exportFluids, int yOffset) {
         ModularUI.Builder builder = ModularUI.defaultBuilder(yOffset);
-        builder.widget(new ProgressWidget(progressSupplier, 78, 23 + yOffset, 20, 20, progressBarTexture, moveType));
+        builder.widget(new RecipeProgressWidget(progressSupplier, 78, 23 + yOffset, 20, 20, progressBarTexture, moveType, this));
         addInventorySlotGroup(builder, importItems, importFluids, false, yOffset);
         addInventorySlotGroup(builder, exportItems, exportFluids, true, yOffset);
         if (this.specialTexture != null && this.specialTexturePosition != null)

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamAlloySmelter.java
@@ -5,6 +5,7 @@ import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.resources.TextureArea;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -49,7 +50,7 @@ public class SteamAlloySmelter extends SteamMetaTileEntity {
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, slotBackground))
                 .widget(new SlotWidget(this.importItems, 1, 35, 25)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, slotBackground))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 79, 26, 20, 16)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 79, 26, 20, 16, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_furnace"),
                                 getFullGuiTexture("progress_bar_%s_furnace_filled"),
                                 MoveType.HORIZONTAL))

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamCompressor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamCompressor.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -40,7 +41,7 @@ public class SteamCompressor extends SteamMetaTileEntity {
         return createUITemplate(player)
                 .widget(new SlotWidget(this.importItems, 0, 53, 25)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, getFullGuiTexture("slot_%s_compressor_background")))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 78, 25, 20, 18)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 78, 25, 20, 18, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_compressor"),
                                 getFullGuiTexture("progress_bar_%s_compressor_filled"),
                                 MoveType.HORIZONTAL))

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamExtractor.java
@@ -3,6 +3,7 @@ package gregtech.common.metatileentities.steam;
 import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -39,7 +40,7 @@ public class SteamExtractor extends SteamMetaTileEntity {
         return createUITemplate(player)
                 .widget(new SlotWidget(this.importItems, 0, 53, 25)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, getFullGuiTexture("slot_%s_extractor_background")))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 79, 25, 20, 18)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 79, 25, 20, 18, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_extractor"),
                                 getFullGuiTexture("progress_bar_%s_extractor_filled"),
                                 ProgressWidget.MoveType.HORIZONTAL))

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamFurnace.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
 import gregtech.api.gui.widgets.ProgressWidget.MoveType;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -45,7 +46,7 @@ public class SteamFurnace extends SteamMetaTileEntity {
         return createUITemplate(player)
                 .widget(new SlotWidget(this.importItems, 0, 53, 25)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, getFullGuiTexture("slot_%s_furnace_background")))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 79, 26, 20, 16)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 79, 26, 20, 16, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_furnace"),
                                 getFullGuiTexture("progress_bar_%s_furnace_filled"),
                                 MoveType.HORIZONTAL))

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamHammer.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ImageWidget;
 import gregtech.api.gui.widgets.ProgressWidget;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -40,7 +41,7 @@ public class SteamHammer extends SteamMetaTileEntity {
         return createUITemplate(player)
                 .widget(new SlotWidget(this.importItems, 0, 53, 25)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, getFullGuiTexture("slot_%s_hammer_background")))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 79, 25, 20, 18)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 79, 25, 20, 18, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_hammer"),
                                 getFullGuiTexture("progress_bar_%s_hammer_filled"),
                                 ProgressWidget.MoveType.VERTICAL))

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamMacerator.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.capability.impl.RecipeLogicSteam;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -42,7 +43,7 @@ public class SteamMacerator extends SteamMetaTileEntity {
         return createUITemplate(player)
                 .widget(new SlotWidget(this.importItems, 0, 53, 25)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, getFullGuiTexture("slot_%s_macerator_background")))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 79, 26, 21, 18)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 79, 26, 21, 18, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_macerator"),
                                 getFullGuiTexture("progress_bar_%s_macerator_filled"),
                                 ProgressWidget.MoveType.HORIZONTAL))

--- a/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
+++ b/src/main/java/gregtech/common/metatileentities/steam/SteamRockBreaker.java
@@ -4,6 +4,7 @@ import gregtech.api.capability.impl.NotifiableItemStackHandler;
 import gregtech.api.capability.impl.RecipeLogicSteam;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.widgets.ProgressWidget;
+import gregtech.api.gui.widgets.RecipeProgressWidget;
 import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
@@ -59,7 +60,7 @@ public class SteamRockBreaker extends SteamMetaTileEntity {
         return createUITemplate(player)
                 .widget(new SlotWidget(this.importItems, 0, 53, 34)
                         .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE, getFullGuiTexture("overlay_%s_dust")))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 79, 35, 21, 18)
+                .widget(new RecipeProgressWidget(workableHandler::getProgressPercent, 79, 35, 21, 18, workableHandler.recipeMap)
                         .setProgressBar(getFullGuiTexture("progress_bar_%s_macerator"),
                                 getFullGuiTexture("progress_bar_%s_macerator_filled"),
                                 ProgressWidget.MoveType.HORIZONTAL))

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -53,8 +53,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
         FluidTank[] exportFluidTanks = new FluidTank[recipeMap.getMaxFluidOutputs()];
         for (int i = 0; i < exportFluidTanks.length; i++)
             exportFluidTanks[i] = new FluidTank(16000);
-        this.modularUI = recipeMap.createUITemplate(
-                () -> timer > 1.0 ? timer += 0.005 : (timer = 0), // simulate recipe progress in JEI
+        this.modularUI = recipeMap.createJeiUITemplate(
                 (importItems = new ItemStackHandler(recipeMap.getMaxInputs())),
                 (exportItems = new ItemStackHandler(recipeMap.getMaxOutputs())),
                 (importFluids = new FluidTankList(false, importFluidTanks)),

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -30,6 +30,7 @@ import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 
 import javax.annotation.Nonnull;
+import java.util.HashMap;
 import java.util.List;
 
 public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
@@ -41,6 +42,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
     private final IDrawable backgroundDrawable;
 
     private final int FONT_HEIGHT = 9;
+    private static final HashMap<RecipeMap<?>, RecipeMapCategory> categoryMap = new HashMap<>();
+    private double timer = 0;
 
     public RecipeMapCategory(RecipeMap<?> recipeMap, IGuiHelper guiHelper) {
         this.recipeMap = recipeMap;
@@ -50,7 +53,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
         FluidTank[] exportFluidTanks = new FluidTank[recipeMap.getMaxFluidOutputs()];
         for (int i = 0; i < exportFluidTanks.length; i++)
             exportFluidTanks[i] = new FluidTank(16000);
-        this.modularUI = recipeMap.createJeiUITemplate(
+        this.modularUI = recipeMap.createUITemplate(
+                () -> timer > 1.0 ? timer += 0.005 : (timer = 0), // simulate recipe progress in JEI
                 (importItems = new ItemStackHandler(recipeMap.getMaxInputs())),
                 (exportItems = new ItemStackHandler(recipeMap.getMaxOutputs())),
                 (importFluids = new FluidTankList(false, importFluidTanks)),
@@ -60,6 +64,7 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
         ).build(new BlankUIHolder(), Minecraft.getMinecraft().player);
         this.modularUI.initWidgets();
         this.backgroundDrawable = guiHelper.createBlankDrawable(modularUI.getWidth(), modularUI.getHeight() * 2 / 3);
+        categoryMap.put(recipeMap, this);
     }
 
     @Override
@@ -170,5 +175,9 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
             });
             widget.drawInForeground(0, 0);
         }
+    }
+
+    public static HashMap<RecipeMap<?>, RecipeMapCategory> getCategoryMap() {
+        return categoryMap;
     }
 }


### PR DESCRIPTION
This particular PR makes all machine GUIs with progress bars be used, when JEI is installed, to open up the particular category page associated with its recipe map. It also displays a small tooltip to do so, as shown below:
![image](https://user-images.githubusercontent.com/80226372/139350563-8f2cdee2-8e77-43a6-9e8b-77929c49a081.png)

This works both with and without JEI.