### PR TITLE
Adjust Implosion Compressor to not half explosives

### DIFF
--- a/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
+++ b/src/main/java/gregtech/api/recipes/builders/ImplosionRecipeBuilder.java
@@ -74,11 +74,10 @@ public class ImplosionRecipeBuilder extends RecipeBuilder<ImplosionRecipeBuilder
     public ValidationResult<Recipe> build() {
 
         //Adjust the explosive type and the explosive amount. This is done here because it was null otherwise, for some reason
-        int amount = Math.max(1, explosivesAmount / 2);
         if (explosivesType == null) {
-            this.explosivesType = new ItemStack(Blocks.TNT, amount);
+            this.explosivesType = new ItemStack(Blocks.TNT, explosivesAmount);
         } else {
-            this.explosivesType = new ItemStack(explosivesType.getItem(), amount, explosivesType.getMetadata());
+            this.explosivesType = new ItemStack(explosivesType.getItem(), explosivesAmount, explosivesType.getMetadata());
         }
         inputs.add(CountableIngredient.from(explosivesType));
 

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -81,7 +81,7 @@ public class MaterialRecipeHandler {
                 RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
                         .input(dustPrefix, mat, 4)
                         .outputs(GTUtility.copyAmount(3, gemStack), GTUtility.copyAmount(2, tinyDarkAshStack))
-                        .explosivesAmount(4)
+                        .explosivesAmount(2)
                         .buildAndRegister();
             }
 

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -390,7 +390,7 @@ public class MachineRecipeLoader {
         COMPRESSOR_RECIPES.recipeBuilder().inputs(MetaItems.INGOT_MIXED_METAL.getStackForm()).outputs(MetaItems.ADVANCED_ALLOY_PLATE.getStackForm()).duration(300).EUt(2).buildAndRegister();
         BENDER_RECIPES.recipeBuilder().inputs(MetaItems.INGOT_MIXED_METAL.getStackForm()).circuitMeta(1).outputs(MetaItems.ADVANCED_ALLOY_PLATE.getStackForm()).duration(100).EUt(8).buildAndRegister();
         FORMING_PRESS_RECIPES.recipeBuilder().inputs(ADVANCED_ALLOY_PLATE.getStackForm(4)).input(OrePrefix.plate, Materials.Diamond).input(OrePrefix.plate, Materials.Iridium, 4).outputs(MetaItems.INGOT_IRIDIUM_ALLOY.getStackForm()).duration(100).EUt(256).buildAndRegister();
-        IMPLOSION_RECIPES.recipeBuilder().inputs(MetaItems.INGOT_IRIDIUM_ALLOY.getStackForm()).outputs(MetaItems.PLATE_IRIDIUM_ALLOY.getStackForm()).output(OrePrefix.dustTiny, Materials.DarkAsh, 4).explosivesAmount(8).buildAndRegister();
+        IMPLOSION_RECIPES.recipeBuilder().inputs(MetaItems.INGOT_IRIDIUM_ALLOY.getStackForm()).outputs(MetaItems.PLATE_IRIDIUM_ALLOY.getStackForm()).output(OrePrefix.dustTiny, Materials.DarkAsh, 4).explosivesAmount(4).buildAndRegister();
         COMPRESSOR_RECIPES.recipeBuilder().inputs(MetaItems.CARBON_FIBERS.getStackForm(2)).outputs(MetaItems.CARBON_MESH.getStackForm()).buildAndRegister();
         COMPRESSOR_RECIPES.recipeBuilder().inputs(MetaItems.CARBON_MESH.getStackForm()).outputs(MetaItems.CARBON_PLATE.getStackForm()).buildAndRegister();
 


### PR DESCRIPTION
**What:**
This PR adjusts the implosion compressor to no longer half the explosive input provided either via property (CT) or method (java). This means that up to 1 stack of explosives can be used in the implosion compressor. I have adjusted the current Implosion Compressor recipes to match this change.

**Outcome:**
Adjusts Implosion Compressor Recipes to no longer half provided explosives.