### PR TITLE
Fix the output of the hand command

### DIFF
--- a/src/main/java/gregtech/common/command/util/CommandHand.java
+++ b/src/main/java/gregtech/common/command/util/CommandHand.java
@@ -87,7 +87,7 @@ public class CommandHand extends CommandBase {
                         Material material = ((MetaPrefixItem) metaItem).getMaterial(stackInHand);
                         OrePrefix orePrefix = ((MetaPrefixItem) metaItem).getOrePrefix();
                         String oreDictName = new UnificationEntry(orePrefix, material).toString();
-                        player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.material_meta_item", orePrefix, material)
+                        player.sendMessage(new TextComponentTranslation("gregtech.command.util.hand.material_meta_item", orePrefix.name(), material)
                                 .setStyle(new Style().setClickEvent(new ClickEvent(Action.OPEN_URL, oreDictName))));
                     }
                 } else {


### PR DESCRIPTION
**What:**
Passes the expected orePrefix name instead of the orePrefix to the localization of the `/gt util hand` command for MetaPrefixItems. This fixes the actual oreprefix name not displaying in the output of the command.

**Outcome:**
Fixes the output of the `/gt util hand` command