### PR TITLE
fix generators only outputting once per second

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
+++ b/src/main/java/gregtech/api/capability/impl/FuelRecipeLogic.java
@@ -114,13 +114,9 @@ public class FuelRecipeLogic extends MTETrait implements IControllable, IFuelabl
         return metaTileEntity.getNotifiedFluidInputList().size() > 0;
     }
 
-    protected boolean hasNotifiableInputs() {
-        return metaTileEntity.getNotifiedFluidInputList().size() != 0;
-    }
-
     protected boolean canWorkWithInputs() {
         // if the inputs were bad last time, check if they've changed before trying to find a new recipe.
-        if (this.invalidInputsForRecipes && hasNotifiableInputs() && !hasNotifiedInputs()) return false;
+        if (this.invalidInputsForRecipes && !hasNotifiedInputs()) return false;
         else {
             this.invalidInputsForRecipes = false;
         }

--- a/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
+++ b/src/main/java/gregtech/api/metatileentity/SimpleGeneratorMetaTileEntity.java
@@ -5,9 +5,9 @@ import codechicken.lib.render.pipeline.IVertexOperation;
 import codechicken.lib.vec.Matrix4;
 import gregtech.api.GTValues;
 import gregtech.api.capability.impl.EnergyContainerHandler;
-import gregtech.api.capability.impl.FilteredFluidHandler;
 import gregtech.api.capability.impl.FluidTankList;
 import gregtech.api.capability.impl.FuelRecipeLogic;
+import gregtech.api.capability.impl.NotifiableFilteredFluidHandler;
 import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
 import gregtech.api.gui.ModularUI.Builder;
@@ -54,7 +54,7 @@ public class SimpleGeneratorMetaTileEntity extends TieredMetaTileEntity {
 
     @Override
     protected FluidTankList createImportFluidHandler() {
-        return new FluidTankList(false, new FilteredFluidHandler(16000)
+        return new FluidTankList(false, new NotifiableFilteredFluidHandler(16000, this, false)
                 .setFillPredicate(this::canInputFluid));
     }
 


### PR DESCRIPTION
Generators would only output energy once per second due to the isObstructed checking. This PR fixes it. Another issue encountered was some generators not starting and consuming inputs due to there being no notifiable inputs, this was also fixed by making generators use notifiable tanks.