### PR TITLE
Fix World Accelerator crash

### DIFF
--- a/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
+++ b/src/main/java/gregtech/common/metatileentities/electric/MetaTileEntityWorldAccelerator.java
@@ -139,7 +139,7 @@ public class MetaTileEntityWorldAccelerator extends TieredMetaTileEntity impleme
                         }
                         if (world.isBlockLoaded(pos)) {
                             for (int i = 0; i < speed; i++) {
-                                if (GTValues.RNG.nextInt(getTier() / 100) == 0) {
+                                if (GTValues.RNG.nextInt(100) < getTier()) {
                                     // Rongmario:
                                     // randomTick instead of updateTick since some modders can mistake where to put their code.
                                     // Fresh IBlockState before every randomTick, this could easily change after every randomTick call


### PR DESCRIPTION
**What:**
Fixes the world accelerator divide by zero crash, due to the rounding of `getTier()/100` that was being passed as the bound to `nextInt()`

**Outcome:**
Fix World Accelerator crash