### PR TITLE
Gem rework

### DIFF
--- a/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
+++ b/src/main/java/gregtech/api/unification/material/materials/FirstDegreeMaterials.java
@@ -198,7 +198,7 @@ public class FirstDegreeMaterials {
         Diamond = new Material.Builder(276, "diamond")
                 .gem(3).ore()
                 .color(0xC8FFFF).iconSet(DIAMOND)
-                .flags(GENERATE_BOLT_SCREW, GENERATE_LENS, GENERATE_GEAR, NO_SMASHING, NO_SMELTING, FLAMMABLE,
+                .flags(GENERATE_BOLT_SCREW, GENERATE_LENS, GENERATE_GEAR, NO_SMASHING, NO_SMELTING,
                         HIGH_SIFTER_OUTPUT, DISABLE_DECOMPOSITION, EXCLUDE_BLOCK_CRAFTING_BY_HAND_RECIPES)
                 .components(Carbon, 1)
                 .toolStats(8.0f, 3.0f, 1280, 15)

--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -11,6 +11,7 @@ import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.stack.MaterialStack;
 import gregtech.api.util.LocalizationUtils;
 import gregtech.api.util.function.TriConsumer;
+import gregtech.common.ConfigHolder;
 import net.minecraft.client.resources.I18n;
 import org.apache.commons.lang3.Validate;
 import stanhebben.zenscript.annotations.ZenClass;
@@ -75,9 +76,9 @@ public class OrePrefix {
     // A regular Gem worth one Dust. Introduced by Eloraam
     public static final OrePrefix gem = new OrePrefix("gem", M, null, MaterialIconType.gem, ENABLE_UNIFICATION, hasGemProperty);
     // A regular Gem worth one small Dust. Introduced by TerraFirmaCraft
-    public static final OrePrefix gemChipped = new OrePrefix("gemChipped", M / 4, null, MaterialIconType.gemChipped, ENABLE_UNIFICATION, hasGemProperty);
+    public static final OrePrefix gemChipped = new OrePrefix("gemChipped", M / 4, null, MaterialIconType.gemChipped, ENABLE_UNIFICATION, hasGemProperty.and(unused -> ConfigHolder.U.generateLowQualityGems));
     // A regular Gem worth two small Dusts. Introduced by TerraFirmaCraft
-    public static final OrePrefix gemFlawed = new OrePrefix("gemFlawed", M / 2, null, MaterialIconType.gemFlawed, ENABLE_UNIFICATION, hasGemProperty);
+    public static final OrePrefix gemFlawed = new OrePrefix("gemFlawed", M / 2, null, MaterialIconType.gemFlawed, ENABLE_UNIFICATION, hasGemProperty.and(unused -> ConfigHolder.U.generateLowQualityGems));
     // A regular Gem worth two Dusts. Introduced by TerraFirmaCraft
     public static final OrePrefix gemFlawless = new OrePrefix("gemFlawless", M * 2, null, MaterialIconType.gemFlawless, ENABLE_UNIFICATION, hasGemProperty);
     // A regular Gem worth four Dusts. Introduced by TerraFirmaCraft

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -194,6 +194,9 @@ public class ConfigHolder {
         @Config.RequiresWorldRestart
         public double multiblockSteamToEU = 0.5;
 
+        @Config.Comment("Whether to generate flawed and chipped gems for materials and recipes involving them. Useful for Terrafirmacraft")
+        public boolean generateLowQualityGems = false;
+
         public static class GT5U {
 
             @Config.Comment("Require Wrench to break machines? Default: false")

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -194,7 +194,7 @@ public class ConfigHolder {
         @Config.RequiresWorldRestart
         public double multiblockSteamToEU = 0.5;
 
-        @Config.Comment("Whether to generate flawed and chipped gems for materials and recipes involving them. Useful for Terrafirmacraft")
+        @Config.Comment("Whether to generate flawed and chipped gems for materials and recipes involving them. Useful for mods like Terrafirmacraft. Default: false")
         public boolean generateLowQualityGems = false;
 
         public static class GT5U {

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -311,10 +311,11 @@ public class MaterialRecipeHandler {
         if (!prevStack.isEmpty()) {
             ModHandler.addShapelessRecipe(String.format("gem_to_gem_%s_%s", prevPrefix, material), prevStack,
                     "h", new UnificationEntry(gemPrefix, material));
-            RecipeMaps.FORGE_HAMMER_RECIPES.recipeBuilder()
+            RecipeMaps.CUTTER_RECIPES.recipeBuilder()
                     .input(gemPrefix, material)
                     .outputs(prevStack)
-                    .duration(20).EUt(16)
+                    .duration(20)
+                    .EUt(16)
                     .buildAndRegister();
         }
     }
@@ -345,7 +346,7 @@ public class MaterialRecipeHandler {
                         .inputs(GTUtility.copyAmount(2, flawlessStack))
                         .notConsumable(OrePrefix.craftingLens, MarkerMaterials.Color.White)
                         .outputs(exquisiteStack)
-                        .duration(4500)
+                        .duration(1200)
                         .EUt(240)
                         .buildAndRegister();
             }

--- a/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/MaterialRecipeHandler.java
@@ -6,6 +6,7 @@ import gregtech.api.recipes.RecipeMaps;
 import gregtech.api.recipes.builders.BlastRecipeBuilder;
 import gregtech.api.recipes.ingredients.IntCircuitIngredient;
 import gregtech.api.unification.OreDictUnifier;
+import gregtech.api.unification.material.MarkerMaterials;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.DustProperty;
@@ -21,16 +22,16 @@ import net.minecraft.item.ItemStack;
 
 import java.util.*;
 
-import static gregtech.api.GTValues.L;
-import static gregtech.api.GTValues.M;
+import static gregtech.api.GTValues.*;
 import static gregtech.api.recipes.RecipeMaps.ALLOY_SMELTER_RECIPES;
 import static gregtech.api.unification.material.info.MaterialFlags.*;
 import static gregtech.api.unification.ore.OrePrefix.*;
 
 public class MaterialRecipeHandler {
 
-    private static final List<OrePrefix> GEM_ORDER = Arrays.asList(
-            OrePrefix.gemChipped, OrePrefix.gemFlawed, OrePrefix.gem, OrePrefix.gemFlawless, OrePrefix.gemExquisite);
+    private static final List<OrePrefix> GEM_ORDER = isModLoaded("terrafirmacraft") ? Arrays.asList(
+            OrePrefix.gemChipped, OrePrefix.gemFlawed, OrePrefix.gem, OrePrefix.gemFlawless, OrePrefix.gemExquisite) :
+            Arrays.asList(OrePrefix.gem, OrePrefix.gemFlawless, OrePrefix.gemExquisite);
 
     private static final Set<Material> circuitRequiringMaterials = new HashSet<>();
 
@@ -46,8 +47,9 @@ public class MaterialRecipeHandler {
         OrePrefix.dustTiny.addProcessingHandler(PropertyKey.DUST, MaterialRecipeHandler::processTinyDust);
 
         for (OrePrefix orePrefix : GEM_ORDER) {
-            orePrefix.addProcessingHandler(PropertyKey.GEM, MaterialRecipeHandler::processGem);
+            orePrefix.addProcessingHandler(PropertyKey.GEM, MaterialRecipeHandler::processGemConversion);
         }
+        OrePrefix.gem.addProcessingHandler(PropertyKey.GEM, MaterialRecipeHandler::processGem);
 
         setMaterialRequiresCircuit(Materials.Silicon);
     }
@@ -57,31 +59,56 @@ public class MaterialRecipeHandler {
     }
 
     public static void processDust(OrePrefix dustPrefix, Material mat, DustProperty property) {
+        ItemStack dustStack = OreDictUnifier.get(dustPrefix, mat);
         if (mat.hasProperty(PropertyKey.GEM)) {
             ItemStack gemStack = OreDictUnifier.get(OrePrefix.gem, mat);
-            ItemStack tinyDarkAshStack = OreDictUnifier.get(OrePrefix.dustTiny, Materials.DarkAsh);
+            ItemStack smallDarkAshStack = OreDictUnifier.get(OrePrefix.dustSmall, Materials.DarkAsh);
+
+            ItemStack exquisiteStack = null;
+            if (!OrePrefix.gemExquisite.isIgnored(mat))
+                exquisiteStack = OreDictUnifier.get(OrePrefix.gemExquisite, mat);
 
             if (mat.hasFlag(CRYSTALLIZABLE)) {
-
                 RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
-                        .input(dustPrefix, mat)
-                        .fluidInputs(Materials.Water.getFluid(200))
+                        .inputs(dustStack)
+                        .fluidInputs(Materials.Water.getFluid(250))
                         .chancedOutput(gemStack, 7000, 1000)
-                        .duration(1500).EUt(24)
-                        .buildAndRegister();
-
-                RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
-                        .input(dustPrefix, mat)
-                        .fluidInputs(Materials.DistilledWater.getFluid(36))
-                        .chancedOutput(gemStack, 9000, 1000)
                         .duration(1200).EUt(24)
                         .buildAndRegister();
 
+                RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
+                        .inputs(dustStack)
+                        .fluidInputs(Materials.DistilledWater.getFluid(50))
+                        .outputs(gemStack)
+                        .duration(600).EUt(24)
+                        .buildAndRegister();
+
+                if (!mat.hasFlag(EXPLOSIVE) && !mat.hasFlag(FLAMMABLE) && exquisiteStack != null) {
+                    RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
+                            .inputs(GTUtility.copyAmount(4, dustStack))
+                            .outputs(exquisiteStack, smallDarkAshStack)
+                            .explosivesAmount(4)
+                            .buildAndRegister();
+
+                    RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
+                            .inputs(GTUtility.copyAmount(4, dustStack))
+                            .outputs(exquisiteStack, smallDarkAshStack)
+                            .explosivesType(MetaItems.DYNAMITE.getStackForm(2))
+                            .buildAndRegister();
+                }
+
             } else if (!mat.hasFlag(EXPLOSIVE) && !mat.hasFlag(FLAMMABLE)) {
+
                 RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
-                        .input(dustPrefix, mat, 4)
-                        .outputs(GTUtility.copyAmount(3, gemStack), GTUtility.copyAmount(2, tinyDarkAshStack))
+                        .inputs(GTUtility.copyAmount(4, dustStack))
+                        .outputs(GTUtility.copyAmount(3, gemStack), smallDarkAshStack)
                         .explosivesAmount(2)
+                        .buildAndRegister();
+
+                RecipeMaps.IMPLOSION_RECIPES.recipeBuilder()
+                        .inputs(GTUtility.copyAmount(4, dustStack))
+                        .outputs(GTUtility.copyAmount(3, gemStack), smallDarkAshStack)
+                        .explosivesType(MetaItems.DYNAMITE.getStackForm())
                         .buildAndRegister();
             }
 
@@ -98,7 +125,7 @@ public class MaterialRecipeHandler {
                     int duration = Math.max(1, (int) (mat.getAverageMass() * blastTemp / 50L));
 
                     BlastRecipeBuilder ingotSmeltingBuilder = RecipeMaps.BLAST_RECIPES.recipeBuilder()
-                            .input(dustPrefix, mat)
+                            .inputs(dustStack)
                             .outputs(ingotStack)
                             .blastFurnaceTemp(blastTemp)
                             .duration(duration).EUt(120);
@@ -119,7 +146,7 @@ public class MaterialRecipeHandler {
         } else {
             if (mat.hasFlag(GENERATE_PLATE) && !mat.hasFlag(EXCLUDE_PLATE_COMPRESSOR_RECIPE)) {
                 RecipeMaps.COMPRESSOR_RECIPES.recipeBuilder()
-                        .input(dustPrefix, mat)
+                        .inputs(dustStack)
                         .outputs(OreDictUnifier.get(OrePrefix.plate, mat))
                         .buildAndRegister();
             }
@@ -270,7 +297,7 @@ public class MaterialRecipeHandler {
 
     }
 
-    public static void processGem(OrePrefix gemPrefix, Material material, GemProperty property) {
+    public static void processGemConversion(OrePrefix gemPrefix, Material material, GemProperty property) {
         long materialAmount = gemPrefix.materialAmount;
         ItemStack crushedStack = OreDictUnifier.getDust(material, materialAmount);
 
@@ -289,6 +316,39 @@ public class MaterialRecipeHandler {
                     .outputs(prevStack)
                     .duration(20).EUt(16)
                     .buildAndRegister();
+        }
+    }
+
+    public static void processGem(OrePrefix gemPrefix, Material material, GemProperty property) {
+        ItemStack gemStack = OreDictUnifier.get(gemPrefix, material);
+
+        ItemStack flawlessStack = null;
+        if (!OrePrefix.gemFlawless.isIgnored(material))
+            flawlessStack = OreDictUnifier.get(OrePrefix.gemFlawless, material);
+
+        ItemStack exquisiteStack = null;
+        if (!OrePrefix.gemExquisite.isIgnored(material))
+            exquisiteStack = OreDictUnifier.get(OrePrefix.gemExquisite, material);
+
+
+        if (flawlessStack != null) {
+            RecipeMaps.LASER_ENGRAVER_RECIPES.recipeBuilder()
+                    .inputs(GTUtility.copyAmount(2, gemStack))
+                    .notConsumable(OrePrefix.craftingLens, MarkerMaterials.Color.White)
+                    .outputs(flawlessStack)
+                    .duration(300)
+                    .EUt(240)
+                    .buildAndRegister();
+
+            if (exquisiteStack != null) {
+                RecipeMaps.LASER_ENGRAVER_RECIPES.recipeBuilder()
+                        .inputs(GTUtility.copyAmount(2, flawlessStack))
+                        .notConsumable(OrePrefix.craftingLens, MarkerMaterials.Color.White)
+                        .outputs(exquisiteStack)
+                        .duration(4500)
+                        .EUt(240)
+                        .buildAndRegister();
+            }
         }
     }
 

--- a/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/OreRecipeHandler.java
@@ -4,6 +4,7 @@ import gregtech.api.GTValues;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.recipes.RecipeBuilder;
 import gregtech.api.recipes.RecipeMaps;
+import gregtech.api.recipes.builders.SimpleRecipeBuilder;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
 import gregtech.api.unification.material.Materials;
@@ -258,27 +259,35 @@ public class OreRecipeHandler {
             ItemStack chippedStack = OreDictUnifier.get(OrePrefix.gemChipped, material);
 
             if (material.hasFlag(HIGH_SIFTER_OUTPUT)) {
-                RecipeMaps.SIFTER_RECIPES.recipeBuilder()
+                RecipeBuilder<SimpleRecipeBuilder> builder = RecipeMaps.SIFTER_RECIPES.recipeBuilder()
                         .input(purifiedPrefix, material)
-                        .chancedOutput(exquisiteStack, 300, 60)
-                        .chancedOutput(flawlessStack, 1200, 180)
-                        .chancedOutput(gemStack, 4500, 540)
-                        .chancedOutput(flawedStack, 1400, 240)
-                        .chancedOutput(chippedStack, 2800, 320)
-                        .chancedOutput(dustStack, 3500, 500)
-                        .duration(800).EUt(16)
-                        .buildAndRegister();
+                        .chancedOutput(exquisiteStack, 500, 150)
+                        .chancedOutput(flawlessStack, 1500, 200)
+                        .chancedOutput(gemStack, 5000, 1000)
+                        .chancedOutput(dustStack, 2500, 500)
+                        .duration(800).EUt(16);
+
+                if (!flawedStack.isEmpty())
+                    builder.chancedOutput(flawedStack, 2000, 500);
+                if (!chippedStack.isEmpty())
+                    builder.chancedOutput(chippedStack, 3000, 350);
+
+                builder.buildAndRegister();
             } else {
-                RecipeMaps.SIFTER_RECIPES.recipeBuilder()
+                RecipeBuilder<SimpleRecipeBuilder> builder = RecipeMaps.SIFTER_RECIPES.recipeBuilder()
                         .input(purifiedPrefix, material)
-                        .chancedOutput(exquisiteStack, 100, 30)
-                        .chancedOutput(flawlessStack, 400, 70)
-                        .chancedOutput(gemStack, 1500, 300)
-                        .chancedOutput(flawedStack, 2000, 240)
-                        .chancedOutput(chippedStack, 4000, 320)
-                        .chancedOutput(dustStack, 5000, 600)
-                        .duration(800).EUt(16)
-                        .buildAndRegister();
+                        .chancedOutput(exquisiteStack, 300, 100)
+                        .chancedOutput(flawlessStack, 1000, 150)
+                        .chancedOutput(gemStack, 3500, 500)
+                        .chancedOutput(dustStack, 5000, 750)
+                        .duration(800).EUt(16);
+
+                if (!flawedStack.isEmpty())
+                    builder.chancedOutput(flawedStack, 2500, 300);
+                if (!exquisiteStack.isEmpty())
+                    builder.chancedOutput(chippedStack, 3500, 400);
+
+                builder.buildAndRegister();
             }
         }
         processMetalSmelting(purifiedPrefix, material, property);

--- a/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/recipe/MachineRecipeLoader.java
@@ -304,9 +304,9 @@ public class MachineRecipeLoader {
 
         RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()
                 .input(OrePrefix.dust, Materials.SiliconDioxide)
-                .fluidInputs(Materials.DistilledWater.getFluid(200))
+                .fluidInputs(Materials.DistilledWater.getFluid(250))
                 .chancedOutput(OreDictUnifier.get(OrePrefix.gem, Materials.Quartzite), 1000, 1000)
-                .duration(1500).EUt(24).buildAndRegister();
+                .duration(1200).EUt(24).buildAndRegister();
 
         //todo find UU-Matter replacement
 //        RecipeMaps.AUTOCLAVE_RECIPES.recipeBuilder()


### PR DESCRIPTION
**What:**
This PR reworks gem related recipes.

**How solved:**
Gem dusts have either one or two paths depending on their flags. If a gem is Crystalizable, it can be autoclaved with water for a chance at a gem, or with distilled water for a guaranteed gem. As long as the gem is not explosive nor flammable, it can also be imploded lossily from the dust to the gem form.

Gems can also be tiered up losslessly in the laser engraver.

Splitting gems into lower tiers has been moved into the more appropriate cutting machine too.

For the sifter, the rates have all been tweaked. One can generally expect to get a bit more total gem dust when sifting than processing the ore a different way. This should incentivize the use of sifting everywhere, instead of only when needed.

Also, the flawed and chipped gems will now not generate unless a config is enabled, in order to remove a lot of clutter, while still keeping mod compat.

**Outcome:**
Overhauled gem related recipes.