### PR TITLE
Separate item and fluid tooltip callbacks

### DIFF
--- a/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/recipe/GTRecipeWrapper.java
@@ -96,7 +96,7 @@ public class GTRecipeWrapper implements IRecipeWrapper {
         }
     }
 
-    public void addTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
+    public void addItemTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
         boolean notConsumed = input && recipe.isNotConsumedInput(ingredient);
         ChanceEntry entry = input ? null : chanceOutput.get(slotIndex);
 
@@ -105,6 +105,14 @@ public class GTRecipeWrapper implements IRecipeWrapper {
             double boost = entry.getBoostPerTier() / 100.0;
             tooltip.add(I18n.format("gregtech.recipe.chance", chance, boost));
         } else if (notConsumed) {
+            tooltip.add(I18n.format("gregtech.recipe.not_consumed"));
+        }
+    }
+
+    public void addFluidTooltip(int slotIndex, boolean input, Object ingredient, List<String> tooltip) {
+        boolean notConsumed = input && recipe.isNotConsumedInput(ingredient);
+
+        if (notConsumed) {
             tooltip.add(I18n.format("gregtech.recipe.not_consumed"));
         }
     }

--- a/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
+++ b/src/main/java/gregtech/integration/jei/recipe/RecipeMapCategory.java
@@ -160,8 +160,8 @@ public class RecipeMapCategory implements IRecipeCategory<GTRecipeWrapper> {
                 }
             }
         }
-        itemStackGroup.addTooltipCallback(recipeWrapper::addTooltip);
-        fluidStackGroup.addTooltipCallback(recipeWrapper::addTooltip);
+        itemStackGroup.addTooltipCallback(recipeWrapper::addItemTooltip);
+        fluidStackGroup.addTooltipCallback(recipeWrapper::addFluidTooltip);
         itemStackGroup.set(ingredients);
         fluidStackGroup.set(ingredients);
     }


### PR DESCRIPTION
**What:**
Separates the JEI tooltip callback into separate item and fluid functions

**Outcome:**
Fixes chance tooltips appearing on fluids in some recipes with chanced item outputs (sapphire/green sapphire slurry centrifuging