### PR TITLE
Fix EBF and MS previews for WireCoil2

### DIFF
--- a/src/main/java/gregtech/integration/jei/multiblock/infos/ElectricBlastFurnaceInfo.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/infos/ElectricBlastFurnaceInfo.java
@@ -51,9 +51,9 @@ public class ElectricBlastFurnaceInfo extends MultiblockInfoPage {
         }
         for (CoilType2 coilType : CoilType2.values()) {
             shapeInfo.add(MultiblockShapeInfo.builder()
-                    .aisle("IFX", "CCC", "CCC", "XXX")
-                    .aisle("SXE", "C#C", "C#C", "XHX")
-                    .aisle("ODM", "CCC", "CCC", "XXX")
+                    .aisle("XEM", "CCC", "CCC", "XXX")
+                    .aisle("FXD", "C#C", "C#C", "XHX")
+                    .aisle("ISO", "CCC", "CCC", "XXX")
                     .where('X', MetaBlocks.METAL_CASING.getState(MetalCasingType.INVAR_HEATPROOF))
                     .where('C', MetaBlocks.WIRE_COIL2.getState(coilType))
                     .where('S', MetaTileEntities.ELECTRIC_BLAST_FURNACE, EnumFacing.WEST)
@@ -62,7 +62,7 @@ public class ElectricBlastFurnaceInfo extends MultiblockInfoPage {
                     .where('I', MetaTileEntities.ITEM_IMPORT_BUS[GTValues.LV], EnumFacing.WEST)
                     .where('O', MetaTileEntities.ITEM_EXPORT_BUS[GTValues.LV], EnumFacing.WEST)
                     .where('F', MetaTileEntities.FLUID_IMPORT_HATCH[GTValues.LV], EnumFacing.NORTH)
-                    .where('D', MetaTileEntities.FLUID_IMPORT_HATCH[GTValues.LV], EnumFacing.SOUTH)
+                    .where('D', MetaTileEntities.FLUID_EXPORT_HATCH[GTValues.LV], EnumFacing.SOUTH)
                     .where('H', MetaTileEntities.MUFFLER_HATCH[GTValues.LV], EnumFacing.UP)
                     .where('M', maintenanceIfEnabled(MetaBlocks.METAL_CASING.getState(MetalCasingType.INVAR_HEATPROOF)), EnumFacing.EAST)
                     .build());

--- a/src/main/java/gregtech/integration/jei/multiblock/infos/MultiSmelterInfo.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/infos/MultiSmelterInfo.java
@@ -49,9 +49,9 @@ public class MultiSmelterInfo extends MultiblockInfoPage {
         }
         for (CoilType2 coilType : CoilType2.values()) {
             shapeInfo.add(MultiblockShapeInfo.builder()
-                    .aisle("IXX", "CCC", "XXX")
-                    .aisle("SXE", "C#C", "XHX")
-                    .aisle("OXM", "CCC", "XXX")
+                    .aisle("XEM", "CCC", "XXX")
+                    .aisle("XXX", "C#C", "XHX")
+                    .aisle("ISO", "CCC", "XXX")
                     .where('X', MetaBlocks.METAL_CASING.getState(MetalCasingType.INVAR_HEATPROOF))
                     .where('C', MetaBlocks.WIRE_COIL2.getState(coilType))
                     .where('S', MetaTileEntities.MULTI_FURNACE, EnumFacing.WEST)


### PR DESCRIPTION
**What:**
Fixes the EBF and Multismelter multiblock previews being disformed for WireCoil2 because of incorrect block layouts. Also changes the WC2 EBF to have a fluid export and import hatch, instead of 2 import hatches, like the WireCoil preview