### PR TITLE
Add material amount cfg

### DIFF
--- a/src/main/java/gregtech/api/unification/ore/OrePrefix.java
+++ b/src/main/java/gregtech/api/unification/ore/OrePrefix.java
@@ -455,18 +455,18 @@ public class OrePrefix {
         }
 
         if (this == block) {
-            //glowstone and nether quartz blocks use 4 gems (dusts)
-            if (material == Materials.Glowstone ||
-                    material == Materials.NetherQuartz ||
-                    material == Materials.Brick ||
-                    material == Materials.Clay)
-                return M * 4;
-                //glass, ice and obsidian gain only one dust
-            else if (material == Materials.Glass ||
-                    material == Materials.Ice ||
-                    material == Materials.Obsidian ||
-                    material == Materials.Concrete)
-                return M;
+            // Use 4 gems (dusts)
+            for (String materialName : ConfigHolder.recipes.materialOutputFourDustRecipes) {
+                if (Objects.equals(materialName, material.getName())) {
+                    return M * 4;
+                }
+            }
+            // Gain only one dust
+            for (String materialName : ConfigHolder.recipes.materialOutputOneDustRecipe) {
+                if (Objects.equals(materialName, material.getName())) {
+                    return M;
+                }
+            }
         } else if (this == stick) {
             if (material == Materials.Blaze)
                 return M * 4;

--- a/src/main/java/gregtech/common/ConfigHolder.java
+++ b/src/main/java/gregtech/common/ConfigHolder.java
@@ -243,6 +243,18 @@ public class ConfigHolder {
 
         @Config.Comment({"Whether to make the recipe for the EBF Controller harder.", "Default: false"})
         public boolean harderEBFControllerRecipe = false;
+
+        @Config.Comment({"Change to 4 like glowstone and nether quartz blocks.",
+                "Default: \"glowstone\", \"nether_quartz\", \"brick\", \"clay\""})
+        public String[] materialOutputFourDustRecipes = new String[]{
+                "glowstone", "nether_quartz", "brick", "clay"
+        };
+
+        @Config.Comment({"Make you get one dust from one block.",
+                "Default: \"glass\", \"ice\", \"obsidian\", \"concrete\""})
+        public String[] materialOutputOneDustRecipe = new String[]{
+                "glass", "ice", "obsidian", "concrete"
+        };
     }
 
     public static class CompatibilityOptions {


### PR DESCRIPTION
## What
The part where the number of pieces is branched directly specified the material, and the modpack creator had to go to the trouble of adding and deleting recipes if they were to get on GT's ore dictionary.
Adding this cfg will reduce the burden on the modpack author.

## Outcome
The material for amount branching can be changed in cfg.

## Potential Compatibility Issues
It shouldn't have any particular impact.