### PR TITLE
Fix Laser Pipe Client Desync + Small Rework

### DIFF
--- a/src/main/java/gregtech/common/pipelike/laser/tile/TileEntityLaserPipe.java
+++ b/src/main/java/gregtech/common/pipelike/laser/tile/TileEntityLaserPipe.java
@@ -156,7 +156,7 @@ public class TileEntityLaserPipe extends TileEntityPipeBase<LaserPipeType, Laser
      * @param duration how long the pipe should be active for
      */
     public void setActive(boolean active, int duration) {
-        if (this.isActive != active){
+        if (this.isActive != active) {
             this.isActive = active;
             notifyBlockUpdate();
             markDirty();


### PR DESCRIPTION
## What
fixes laser pipe not syncing `isActive` to client on world load
small rework to `setActive()` to make it simpler

## Implementation Details
made `setActive()` simpler
moved the lambda in `schedualTask()` to its own method reference
add initial sync methods and call `schedualTask()` on sending data

## Outcome
laser renders at the correct times,

## Potential Compatibility Issues
none
