### PR TITLE
Update RecipeMap.java

### DIFF
--- a/src/main/java/gregtech/api/recipes/RecipeMap.java
+++ b/src/main/java/gregtech/api/recipes/RecipeMap.java
@@ -321,6 +321,11 @@ public class RecipeMap<R extends RecipeBuilder<R>> {
         return this;
     }
 
+    public RecipeMap<R> disallowEmptyOutput() {
+        this.allowEmptyOutput = false;
+        return this;
+    }
+
     public RecipeMap<R> setSmallRecipeMap(RecipeMap<?> recipeMap) {
         this.smallRecipeMap = recipeMap;
         return this;


### PR DESCRIPTION
## What
Added a setter to false for `allowEmptyOutput`. Required when a mod/pack adds outputs to the Gas-/Combustion Generator for example.

## Outcome
It adds a setter for the private field `allowEmptyOutput` in RecipeMap.java