### PR TITLE
Allow ITNT and PowderBarrels to make AE singularities

### DIFF
--- a/src/main/java/gregtech/common/EventHandlers.java
+++ b/src/main/java/gregtech/common/EventHandlers.java
@@ -56,7 +56,6 @@ import net.minecraftforge.event.world.ExplosionEvent;
 import net.minecraftforge.event.world.WorldEvent;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -391,8 +390,7 @@ public class EventHandlers {
         }
     }
 
-    @Optional.Method(modid = Mods.Names.APPLIED_ENERGISTICS2)
     private static boolean checkAEEntity(Entity entity) {
-        return entity instanceof EntitySingularity;
+        return Mods.AppliedEnergistics2.isModLoaded() && entity instanceof EntitySingularity;
     }
 }


### PR DESCRIPTION
## What
Allows ITNT and Powderbarrels to make AE entangled singularities by exempting them from the removal from the list of entities affected by the explosion, so that they can run their own logic.

## Outcome
Allows ITNT and Powderbarrels to make entagled AE singularities.
