### PR TITLE
Rework Item Handler List

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -35,20 +35,20 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
         this(Collections.emptyList());
     }
 
-    public ItemHandlerList(ItemHandlerList parent, IItemHandler... additional) {
-        this(parent);
-        Collections.addAll(this, additional);
+    public static ItemHandlerList of(IItemHandler... handlers) {
+        ItemHandlerList list = new ItemHandlerList();
+        if (handlers != null && handlers.length > 0) {
+            Collections.addAll(list, handlers);
+        }
+        return list.toImmutable();
     }
 
     /**
      * @param handler the handler to get the slot offset of
-     * @return the slot offset
-     * @throws IllegalArgumentException if the handler is not in this list
+     * @return the slot offset, or {@code -1} if the handler does not exist
      */
     public int getIndexOffset(IItemHandler handler) {
-        int offset = baseIndexOffset.get(handler);
-        if (offset == -1) throw new IllegalArgumentException();
-        return offset;
+        return baseIndexOffset.get(handler);
     }
 
     @NotNull

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -155,7 +155,7 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
             throw new IllegalArgumentException("Attempted to add item handler " + element + " twice");
         }
 
-        int offset = handlerBySlotIndex.size();
+        int offset = getSlots();
         baseIndexOffset.put(element, offset);
         for (int slotIndex = 0; slotIndex < element.getSlots(); slotIndex++) {
             handlerBySlotIndex.put(offset + slotIndex, element);

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -149,7 +149,7 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
     }
 
     @Override
-    public void add(int unused, IItemHandler element) {
+    public void add(int unused, @NotNull IItemHandler element) {
         Objects.requireNonNull(element);
         if (baseIndexOffset.containsKey(element)) {
             throw new IllegalArgumentException("Attempted to add item handler " + element + " twice");
@@ -176,9 +176,7 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
 
     @Override
     public IItemHandler remove(int index) {
-        if (invalidIndex(index)) {
-            throw new IndexOutOfBoundsException();
-        }
+        if (invalidIndex(index)) throw new IndexOutOfBoundsException();
 
         IItemHandler handler = get(index);
 
@@ -208,13 +206,29 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
         return handler;
     }
 
+    @Override
+    public int indexOf(@NotNull Object o) {
+        for (int i = 0; i < size(); i++) {
+            if (Objects.equals(o, get(i)))
+                return i;
+        }
+        return -1;
+    }
+
+    @Override
+    public int lastIndexOf(@NotNull Object o) {
+        for (int i = size() - 1; i >= 0; i--) {
+            if (Objects.equals(o, get(i)))
+                return i;
+        }
+        return -1;
+    }
+
     private boolean invalidSlot(int slot) {
-        if (handlerBySlotIndex.isEmpty()) return false;
         return slot < 0 || slot >= handlerBySlotIndex.size();
     }
 
     private boolean invalidIndex(int index) {
-        if (baseIndexOffset.isEmpty()) return false;
         return index < 0 || index >= baseIndexOffset.size();
     }
 
@@ -241,7 +255,7 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
         }
 
         @Override
-        public void add(int unused, IItemHandler element) {
+        public void add(int unused, @NotNull IItemHandler element) {
             // no op?
             throw new UnsupportedOperationException();
         }

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -236,11 +236,7 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
 
     private void updateHandlerArray() {
         if (handlers.length != size()) {
-            handlers = new IItemHandler[size()];
-            int i = 0;
-            for (IItemHandler h : baseIndexOffset.keySet()) {
-                handlers[i++] = h;
-            }
+            handlers = baseIndexOffset.keySet().toArray(new IItemHandler[size()]);
         }
     }
 

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -137,10 +137,11 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
 
     @Override
     public boolean add(IItemHandler handler) {
+        if (this == handler) {
+            throw new IllegalArgumentException("Cannot add a handler list to itself!");
+        }
         int s = size();
         if (handler instanceof ItemHandlerList list) {
-            // possible infinite recursion
-            // throw instead?
             addAll(s, list);
         } else {
             add(s, handler);

--- a/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
+++ b/src/main/java/gregtech/api/capability/impl/ItemHandlerList.java
@@ -1,5 +1,8 @@
 package gregtech.api.capability.impl;
 
+import gregtech.api.capability.INotifiableHandler;
+import gregtech.api.metatileentity.MetaTileEntity;
+
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -15,7 +18,7 @@ import java.util.*;
 /**
  * Efficiently delegates calls into multiple item handlers
  */
-public class ItemHandlerList extends AbstractList<IItemHandler> implements IItemHandlerModifiable {
+public class ItemHandlerList extends AbstractList<IItemHandler> implements IItemHandlerModifiable, INotifiableHandler {
 
     protected final Int2ObjectMap<IItemHandler> handlerBySlotIndex = new Int2ObjectOpenHashMap<>();
     protected final Object2IntMap<IItemHandler> baseIndexOffset = new Object2IntArrayMap<>();
@@ -107,6 +110,24 @@ public class ItemHandlerList extends AbstractList<IItemHandler> implements IItem
     @NotNull
     public Collection<IItemHandler> getBackingHandlers() {
         return Collections.unmodifiableCollection(baseIndexOffset.keySet());
+    }
+
+    @Override
+    public void addNotifiableMetaTileEntity(MetaTileEntity metaTileEntity) {
+        for (IItemHandler handler : this) {
+            if (handler instanceof INotifiableHandler notifiableHandler) {
+                notifiableHandler.addNotifiableMetaTileEntity(metaTileEntity);
+            }
+        }
+    }
+
+    @Override
+    public void removeNotifiableMetaTileEntity(MetaTileEntity metaTileEntity) {
+        for (IItemHandler handler : this) {
+            if (handler instanceof INotifiableHandler notifiableHandler) {
+                notifiableHandler.removeNotifiableMetaTileEntity(metaTileEntity);
+            }
+        }
     }
 
     @Override

--- a/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
+++ b/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
@@ -2,13 +2,14 @@ package gregtech.api.capability.impl;
 
 import gregtech.Bootstrap;
 
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
+import java.util.Objects;
 
 public class ItemHandlerListTest {
 
@@ -19,18 +20,24 @@ public class ItemHandlerListTest {
 
     @Test
     public void testListOperations() {
-        var list = new ItemHandlerList(Collections.emptyList());
+        var list = new ItemHandlerList();
+        ItemStackHandler firstHandler = new ItemStackHandler(16);
+        ItemStackHandler secondHandler = new ItemStackHandler(16);
 
         // test add
-        list.add(new ItemStackHandler(16));
-//        MatcherAssert.assertThat("size is wrong", list.getSlots() == 16);
-        list.add(new ItemStackHandler(16));
-//        MatcherAssert.assertThat("size is wrong", list.getSlots() == 32);
-//        MatcherAssert.assertThat("size is wrong", list.size() == 2);
+        list.add(firstHandler);
+        MatcherAssert.assertThat("wrong number of slots!", list.getSlots() == 16);
+        MatcherAssert.assertThat("wrong number of handlers!", list.size() == 1);
+        list.add(secondHandler);
+        MatcherAssert.assertThat("wrong number of slots!", list.getSlots() == 32);
+        MatcherAssert.assertThat("wrong number of handlers!", list.size() == 2);
 
         // test removal
-        list.remove(0);
-//        MatcherAssert.assertThat("size is wrong", list.getSlots() == 16);
-//        MatcherAssert.assertThat("size is wrong", list.size() == 1);
+        IItemHandler removed = list.remove(0);
+        MatcherAssert.assertThat("wrong number of slots!", list.getSlots() == 16);
+        MatcherAssert.assertThat("wrong number of handlers!", list.size() == 1);
+        MatcherAssert.assertThat("removed handler is not the first handler!", Objects.equals(removed, firstHandler));
+        int newIndex = list.getIndexOffset(secondHandler);
+        MatcherAssert.assertThat("second handler was not updated!", newIndex == 0);
     }
 }

--- a/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
+++ b/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
@@ -5,11 +5,12 @@ import gregtech.Bootstrap;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
+
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ItemHandlerListTest {
 
@@ -26,18 +27,48 @@ public class ItemHandlerListTest {
 
         // test add
         list.add(firstHandler);
-        MatcherAssert.assertThat("wrong number of slots!", list.getSlots() == 16);
-        MatcherAssert.assertThat("wrong number of handlers!", list.size() == 1);
+        assertThat("wrong number of slots!", list.getSlots() == 16);
+        assertThat("wrong number of handlers!", list.size() == 1);
         list.add(secondHandler);
-        MatcherAssert.assertThat("wrong number of slots!", list.getSlots() == 32);
-        MatcherAssert.assertThat("wrong number of handlers!", list.size() == 2);
+        assertThat("wrong number of slots!", list.getSlots() == 32);
+        assertThat("wrong number of handlers!", list.size() == 2);
 
         // test removal
         IItemHandler removed = list.remove(0);
-        MatcherAssert.assertThat("wrong number of slots!", list.getSlots() == 16);
-        MatcherAssert.assertThat("wrong number of handlers!", list.size() == 1);
-        MatcherAssert.assertThat("removed handler is not the first handler!", Objects.equals(removed, firstHandler));
+        assertThat("wrong number of slots!", list.getSlots() == 16);
+        assertThat("wrong number of handlers!", list.size() == 1);
+        assertThat("removed handler is not the first handler!", Objects.equals(removed, firstHandler));
         int newIndex = list.getIndexOffset(secondHandler);
-        MatcherAssert.assertThat("second handler was not updated!", newIndex == 0);
+        assertThat("second handler was not updated!", newIndex == 0);
+
+        IItemHandler get = list.get(0);
+        assertThat("Second handler is not first!", get == secondHandler);
+
+        // test add after removal
+        list.add(firstHandler);
+
+        get = list.get(1);
+        assertThat("First handler is not second!", get == firstHandler);
+        assertThat("wrong number of slots!", list.getSlots() == 32);
+        assertThat("wrong number of handlers!", list.size() == 2);
+
+        // test immutable
+        ItemHandlerList immutable = list.toImmutable();
+
+        boolean testRemove = false;
+        try {
+            immutable.remove(0);
+        } catch (UnsupportedOperationException ignored) {
+            testRemove = true;
+        }
+        assertThat("list was modified!", testRemove);
+
+        boolean testAdd = false;
+        try {
+            immutable.add(firstHandler);
+        } catch (UnsupportedOperationException ignored) {
+            testAdd = true;
+        }
+        assertThat("list was modified!", testAdd);
     }
 }

--- a/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
+++ b/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
@@ -55,20 +55,14 @@ public class ItemHandlerListTest {
         // test immutable
         ItemHandlerList immutable = list.toImmutable();
 
-        boolean testRemove = false;
         try {
             immutable.remove(0);
-        } catch (UnsupportedOperationException ignored) {
-            testRemove = true;
-        }
-        assertThat("list was modified!", testRemove);
+            assertThat("list was modified!", false);
+        } catch (UnsupportedOperationException ignored) {}
 
-        boolean testAdd = false;
         try {
             immutable.add(firstHandler);
-        } catch (UnsupportedOperationException ignored) {
-            testAdd = true;
-        }
-        assertThat("list was modified!", testAdd);
+            assertThat("list was modified!", false);
+        } catch (UnsupportedOperationException ignored) {}
     }
 }

--- a/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
+++ b/src/test/java/gregtech/api/capability/impl/ItemHandlerListTest.java
@@ -1,0 +1,36 @@
+package gregtech.api.capability.impl;
+
+import gregtech.Bootstrap;
+
+import net.minecraftforge.items.ItemStackHandler;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+public class ItemHandlerListTest {
+
+    @BeforeAll
+    public static void bootstrap() {
+        Bootstrap.perform();
+    }
+
+    @Test
+    public void testListOperations() {
+        var list = new ItemHandlerList(Collections.emptyList());
+
+        // test add
+        list.add(new ItemStackHandler(16));
+//        MatcherAssert.assertThat("size is wrong", list.getSlots() == 16);
+        list.add(new ItemStackHandler(16));
+//        MatcherAssert.assertThat("size is wrong", list.getSlots() == 32);
+//        MatcherAssert.assertThat("size is wrong", list.size() == 2);
+
+        // test removal
+        list.remove(0);
+//        MatcherAssert.assertThat("size is wrong", list.getSlots() == 16);
+//        MatcherAssert.assertThat("size is wrong", list.size() == 1);
+    }
+}


### PR DESCRIPTION
## What
Reworks ItemHandlerList to be more like a list. You can now add/remove handlers from the list as you would expect, and there is an immutable version as well. Introduces tests to ensure ItemHandlerList works as expected.

## Implementation Details
you can add/remove handlers
set is not supported atm
list implements notifiable and delegates those calls to internal handlers
new tests for list operations
should item handler list be final? along with the immutable class?

## Outcome
This wouldn't have any user-facing changes, but it makes ItemHandlerList easier to work with as devs
