### PR TITLE
Fix pipenet insertion NPE caused by `isFaceBlocked`

### DIFF
--- a/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
+++ b/src/main/java/gregtech/api/pipenet/tile/TileEntityPipeBase.java
@@ -278,6 +278,7 @@ public abstract class TileEntityPipeBase<PipeType extends Enum<PipeType> & IPipe
 
     @Override
     public boolean isFaceBlocked(EnumFacing side) {
+        if (side == null) return true; // says hey, you can't insert from nowhere
         return isFaceBlocked(blockedConnections, side);
     }
 


### PR DESCRIPTION
## What
Some machines (like RFTools storage scanner) would get the itemNetHandler with the facing `null`, and throw a NPE when trying to insert things due to `isFaceBlocked` calling `EnumFacing#getIndex()`

This would also fix the same potential crash for fluid pipenets