### PR TITLE
Add method to MetaValueItem to create an ItemStack with capability NBT

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/CombinedCapabilityProvider.java
+++ b/src/main/java/gregtech/api/capability/impl/CombinedCapabilityProvider.java
@@ -1,15 +1,17 @@
 package gregtech.api.capability.impl;
 
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
+import net.minecraftforge.common.util.INBTSerializable;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
-public class CombinedCapabilityProvider implements ICapabilityProvider {
+public class CombinedCapabilityProvider implements ICapabilityProvider, INBTSerializable<NBTTagCompound> {
 
     private final ICapabilityProvider[] providers;
 
@@ -41,5 +43,34 @@ public class CombinedCapabilityProvider implements ICapabilityProvider {
             }
         }
         return null;
+    }
+
+    @Override
+    public NBTTagCompound serializeNBT() {
+        NBTTagCompound tag = new NBTTagCompound();
+
+        int index = 0;
+        for (ICapabilityProvider provider : providers) {
+            if (provider instanceof INBTSerializable<?>serializable) {
+                tag.setTag(String.valueOf(index++), serializable.serializeNBT());
+            }
+        }
+
+        return tag;
+    }
+
+    @Override
+    public void deserializeNBT(NBTTagCompound tag) {
+        int index = 0;
+        for (ICapabilityProvider provider : providers) {
+            // Me when no runtime generic type information :joy:
+            // This will probably not explode since it'll deserialize in the same order it was serialized so the types
+            // should match up.
+            // noinspection rawtypes
+            if (provider instanceof INBTSerializable serializable) {
+                // noinspection unchecked
+                serializable.deserializeNBT(tag.getTag(String.valueOf(index++)));
+            }
+        }
     }
 }

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -1011,6 +1011,10 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             return new ItemStack(MetaItem.this, amount, metaItemOffset + metaValue);
         }
 
+        public ItemStack getStackForm(int amount, @Nullable NBTTagCompound withNBT) {
+            return new ItemStack(MetaItem.this, amount, metaItemOffset + metaValue, withNBT);
+        }
+
         public boolean isItemEqual(ItemStack itemStack) {
             return itemStack.getItem() == MetaItem.this && itemStack.getItemDamage() == (metaItemOffset + metaValue);
         }

--- a/src/main/java/gregtech/api/items/metaitem/MetaItem.java
+++ b/src/main/java/gregtech/api/items/metaitem/MetaItem.java
@@ -1011,8 +1011,8 @@ public abstract class MetaItem<T extends MetaItem<?>.MetaValueItem> extends Item
             return new ItemStack(MetaItem.this, amount, metaItemOffset + metaValue);
         }
 
-        public ItemStack getStackForm(int amount, @Nullable NBTTagCompound withNBT) {
-            return new ItemStack(MetaItem.this, amount, metaItemOffset + metaValue, withNBT);
+        public ItemStack getStackForm(int amount, @Nullable NBTTagCompound capabilityNBT) {
+            return new ItemStack(MetaItem.this, amount, metaItemOffset + metaValue, capabilityNBT);
         }
 
         public boolean isItemEqual(ItemStack itemStack) {


### PR DESCRIPTION
## What
Adds a method to `MetaValueItem` to create an `ItemStack`s capabilities with a certain NBT tag.
Idk why forge decided to have capabilities act on a separate NBT tag than the one of the item stack.