### PR TITLE
Fix Recipe Repair modifications being on client only

### DIFF
--- a/src/main/resources/mixins.gregtech.minecraft.json
+++ b/src/main/resources/mixins.gregtech.minecraft.json
@@ -9,18 +9,18 @@
   },
   "mixins": [
     "BlockConcretePowderMixin",
-    "ContainerMixin",
     "BlockRenderLayerMixin",
+    "ContainerMixin",
     "DamageSourceMixin",
     "EnchantmentCanApplyMixin",
-    "MinecraftMixin"
+    "MinecraftMixin",
+    "RecipeRepairItemMixin"
   ],
   "client": [
     "BlockMixin",
     "EntityRendererMixin",
     "LayerArmorBaseMixin",
     "LayerCustomHeadMixin",
-    "RecipeRepairItemMixin",
     "RegionRenderCacheBuilderMixin",
     "RenderChunkMixin",
     "RenderGlobalMixin",


### PR DESCRIPTION
## What
Fixes the Recipe Repair Mixins being on the client only. This leads to issues when attempting to repair tools when playing on a server.

## Outcome
Fix some dupes, etc.
