### PR TITLE
Fix Crafting Station Partial Dupe Bug

### DIFF
--- a/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
+++ b/src/main/java/gregtech/common/mui/widget/workbench/CraftingOutputSlot.java
@@ -138,8 +138,8 @@ public class CraftingOutputSlot extends Widget<CraftingOutputSlot> implements In
                         if (data.shift) {
                             ItemStack finalStack = outputStack.copy();
                             while (quickTransfer(finalStack, true) &&
-                                    finalStack.getCount() < outputStack.getMaxStackSize()) {
-                                if (!recipeLogic.performRecipe()) break;
+                                    canStack(finalStack, outputStack) &&
+                                    recipeLogic.performRecipe()) {
                                 finalStack.setCount(finalStack.getCount() + outputStack.getCount());
                                 handleItemCraft(outputStack, player);
                             }
@@ -151,6 +151,11 @@ public class CraftingOutputSlot extends Widget<CraftingOutputSlot> implements In
                 }
                 ForgeHooks.setCraftingPlayer(null);
             }
+        }
+
+        private static boolean canStack(ItemStack a, ItemStack b) {
+            return ItemHandlerHelper.canItemStacksStackRelaxed(a, b) &&
+                    a.getCount() + b.getCount() < b.getMaxStackSize();
         }
 
         private boolean insertStack(ItemStack fromStack, ModularSlot toSlot, boolean simulate) {


### PR DESCRIPTION
## What
Fixes a partial dupe bug in the Crafting Station when shift clicking the output slot

## Implementation Details
While adding `+ outputStack.getCount()` in the while loop would be a simple fix to the above issue, it also revealed an issues in `CraftingRecipeLogic#performRecipe()`.
All of the input slot update code is in it's own method now
While I was doing a pass over everything, I spotted small areas of improvement. 
(sure hope it doesn't result in bugs :clueless:)

## Outcome
Crafting Station dupe allegations can finally be over... maybe

## Additional Information
The Crafting Station is Fixed. The Crafting Station is Fixed. The Crafting Station is Fixed. The Crafting Station is Fixed. 
