### PR TITLE
Treat `Byte`s in `ProspectingTexture#map` as UByte & switch to fastutil maps

### DIFF
--- a/src/main/java/gregtech/common/gui/widget/prospector/ProspectingTexture.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/ProspectingTexture.java
@@ -14,12 +14,13 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 
+import it.unimi.dsi.fastutil.bytes.Byte2ObjectOpenHashMap;
 import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
-import java.util.HashMap;
+import java.util.Map;
 
 public class ProspectingTexture extends AbstractTexture {
 
@@ -29,8 +30,8 @@ public class ProspectingTexture extends AbstractTexture {
     private boolean darkMode;
     private int imageWidth = -1;
     private int imageHeight = -1;
-    public final HashMap<Byte, String>[][] map;
-    public static HashMap<Byte, String> emptyTag = new HashMap<>();
+    public final Map<Byte, String>[][] map;
+    public static Map<Byte, String> emptyTag = new Byte2ObjectOpenHashMap<>();
     private int playerXGui;
     private int playerYGui;
     private final ProspectorMode mode;
@@ -42,10 +43,10 @@ public class ProspectingTexture extends AbstractTexture {
         this.mode = mode;
         if (this.mode == ProspectorMode.FLUID) {
             // noinspection unchecked
-            map = new HashMap[(radius * 2 - 1)][(radius * 2 - 1)];
+            map = new Byte2ObjectOpenHashMap[(radius * 2 - 1)][(radius * 2 - 1)];
         } else {
             // noinspection unchecked
-            map = new HashMap[(radius * 2 - 1) * 16][(radius * 2 - 1) * 16];
+            map = new Byte2ObjectOpenHashMap[(radius * 2 - 1) * 16][(radius * 2 - 1) * 16];
         }
     }
 
@@ -102,7 +103,7 @@ public class ProspectingTexture extends AbstractTexture {
 
         for (int i = 0; i < wh; i++) {
             for (int j = 0; j < wh; j++) {
-                HashMap<Byte, String> data = this.map[this.mode == ProspectorMode.ORE ? i : i / 16][this.mode ==
+                Map<Byte, String> data = this.map[this.mode == ProspectorMode.ORE ? i : i / 16][this.mode ==
                         ProspectorMode.ORE ? j : j / 16];
                 // draw bg
                 image.setRGB(i, j, ((data == null) ^ darkMode) ? Color.darkGray.getRGB() : Color.WHITE.getRGB());

--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -1,6 +1,5 @@
 package gregtech.common.gui.widget.prospector.widget;
 
-import com.google.common.primitives.UnsignedBytes;
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.unification.OreDictUnifier;
@@ -37,6 +36,7 @@ import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
+import com.google.common.primitives.UnsignedBytes;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;

--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -1,5 +1,6 @@
 package gregtech.common.gui.widget.prospector.widget;
 
+import com.google.common.primitives.UnsignedBytes;
 import gregtech.api.gui.IRenderContext;
 import gregtech.api.gui.Widget;
 import gregtech.api.unification.OreDictUnifier;
@@ -271,7 +272,7 @@ public class WidgetProspectingMap extends Widget {
                                 if (ProspectingTexture.SELECTED_ALL.equals(texture.getSelected()) ||
                                         texture.getSelected().equals(dict)) {
                                     oreInfo.put(name, oreInfo.getOrDefault(name, 0) + 1);
-                                    oreHeight.put(name, oreHeight.getOrDefault(name, 0) + height.intValue());
+                                    oreHeight.put(name, oreHeight.getOrDefault(name, 0) + UnsignedBytes.toInt(height));
                                     if (oreInfo.get(name) > maxAmount[0]) {
                                         maxAmount[0] = oreInfo.get(name);
                                         MaterialStack m = OreDictUnifier.getMaterial(OreDictUnifier.get(dict));

--- a/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
+++ b/src/main/java/gregtech/common/gui/widget/prospector/widget/WidgetProspectingMap.java
@@ -36,7 +36,6 @@ import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-import com.google.common.primitives.UnsignedBytes;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -272,7 +271,7 @@ public class WidgetProspectingMap extends Widget {
                                 if (ProspectingTexture.SELECTED_ALL.equals(texture.getSelected()) ||
                                         texture.getSelected().equals(dict)) {
                                     oreInfo.put(name, oreInfo.getOrDefault(name, 0) + 1);
-                                    oreHeight.put(name, oreHeight.getOrDefault(name, 0) + UnsignedBytes.toInt(height));
+                                    oreHeight.put(name, oreHeight.getOrDefault(name, 0) + Byte.toUnsignedInt(height));
                                     if (oreInfo.get(name) > maxAmount[0]) {
                                         maxAmount[0] = oreInfo.get(name);
                                         MaterialStack m = OreDictUnifier.getMaterial(OreDictUnifier.get(dict));


### PR DESCRIPTION
## What
Fixes an oversight in #2726, where `Byte`s in `ProspectingTexture#map` aren't treated as unsigned as intended, resulting MCTian-mi/SussyPatches#32, where the same feature was implemented for 2.8.10.

Also replaced original `HashMap<Byte, String>`s with `Byte2ObjectOpenHashMap`s from fastutil.

## Implementation Details
Replaced the `Byte#intValue`  method call with `Byte#toUnsignedInt`, whose implementation is:
```java
    /**
     * Converts the argument to an {@code int} by an unsigned
     * conversion.  In an unsigned conversion to an {@code int}, the
     * high-order 24 bits of the {@code int} are zero and the
     * low-order 8 bits are equal to the bits of the {@code byte} argument.
     *
     * Consequently, zero and positive {@code byte} values are mapped
     * to a numerically equal {@code int} value and negative {@code
     * byte} values are mapped to an {@code int} value equal to the
     * input plus 2<sup>8</sup>.
     *
     * @param  x the value to convert to an unsigned {@code int}
     * @return the argument converted to {@code int} by an unsigned
     *         conversion
     * @since 1.8
     */
    public static int toUnsignedInt(byte x) {
        return ((int) x) & 0xff;
    }
  ```