### PR TITLE
Fix toolbelt copper credit bug

### DIFF
--- a/src/main/java/gregtech/api/items/toolitem/ItemGTToolbelt.java
+++ b/src/main/java/gregtech/api/items/toolitem/ItemGTToolbelt.java
@@ -265,6 +265,14 @@ public class ItemGTToolbelt extends ItemGTTool implements IDyeableItem {
     }
 
     @Override
+    public int getMetadata(ItemStack stack) {
+        ItemStack selected = getHandler(stack).getSelectedStack();
+        if (!selected.isEmpty()) {
+            return selected.getItem().getMetadata(selected);
+        } else return super.getMetadata(stack);
+    }
+
+    @Override
     public boolean isDamaged(@NotNull ItemStack stack) {
         ItemStack selected = getHandler(stack).getSelectedStack();
         if (!selected.isEmpty()) {

--- a/src/main/java/gregtech/common/items/ToolItems.java
+++ b/src/main/java/gregtech/common/items/ToolItems.java
@@ -9,6 +9,7 @@ import gregtech.common.items.tool.*;
 import gregtech.core.sound.GTSoundEvents;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.block.model.ModelBakery;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.enchantment.EnumEnchantmentType;
 import net.minecraft.entity.monster.EntityGolem;
@@ -374,7 +375,14 @@ public final class ToolItems {
     }
 
     public static void registerModels() {
-        TOOLS.forEach(tool -> ModelLoader.setCustomModelResourceLocation(tool.get(), 0, tool.getModelLocation()));
+        for (IGTTool tool : TOOLS) {
+            if (tool == TOOLBELT) {
+                ModelLoader.setCustomMeshDefinition(tool.get(), s -> tool.getModelLocation());
+                ModelBakery.registerItemVariants(tool.get(), tool.getModelLocation());
+            } else {
+                ModelLoader.setCustomModelResourceLocation(tool.get(), 0, tool.getModelLocation());
+            }
+        }
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
## What
Fixes an issue where the toolbelt would convert things to copper credits sometimes, due to some... poorly written... vanilla code.

## Implementation Details
getMetadata has joined the list of methods that have passthrough

## Outcome
No more spraycans becoming copper credits