### PR TITLE
[Refacor/Bugfix] Clear only fluid nbt for `GTFluidHandlerItemStack`

### DIFF
--- a/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java
@@ -69,22 +69,11 @@ public class GTFluidHandlerItemStack extends FluidHandlerItemStack implements IF
     }
 
     @Override
-    public FluidStack drain(FluidStack resource, boolean doDrain) {
-        FluidStack drained = super.drain(resource, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    @Override
-    public FluidStack drain(int maxDrain, boolean doDrain) {
-        FluidStack drained = super.drain(maxDrain, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(boolean doDrain) {
-        if (doDrain && this.getFluid() == null) {
-            this.container.setTagCompound(null);
+    protected void setContainerToEmpty() {
+        super.setContainerToEmpty();
+        var tag = container.getTagCompound();
+        if (tag != null && tag.isEmpty()) {
+            container.setTagCompound(null);
         }
     }
 

--- a/src/main/java/gregtech/api/capability/impl/GTSimpleFluidHandlerItemStack.java
+++ b/src/main/java/gregtech/api/capability/impl/GTSimpleFluidHandlerItemStack.java
@@ -69,26 +69,6 @@ public class GTSimpleFluidHandlerItemStack extends FluidHandlerItemStackSimple i
     }
 
     @Override
-    public FluidStack drain(FluidStack resource, boolean doDrain) {
-        FluidStack drained = super.drain(resource, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    @Override
-    public FluidStack drain(int maxDrain, boolean doDrain) {
-        FluidStack drained = super.drain(maxDrain, doDrain);
-        this.removeTagWhenEmpty(doDrain);
-        return drained;
-    }
-
-    private void removeTagWhenEmpty(boolean doDrain) {
-        if (doDrain && this.getFluid() == null) {
-            this.container.setTagCompound(null);
-        }
-    }
-
-    @Override
     public boolean canFillFluidType(FluidStack fluid) {
         return canFill() && (this.filter == null || this.filter.test(fluid));
     }
@@ -96,6 +76,15 @@ public class GTSimpleFluidHandlerItemStack extends FluidHandlerItemStackSimple i
     @Override
     public boolean canDrainFluidType(FluidStack fluid) {
         return canDrain();
+    }
+
+    @Override
+    protected void setContainerToEmpty() {
+        super.setContainerToEmpty();
+        var tag = container.getTagCompound();
+        if (tag != null && tag.isEmpty()) {
+            container.setTagCompound(null);
+        }
     }
 
     private final class TankProperties implements IFluidTankProperties {


### PR DESCRIPTION
## What
The implementation of `GTFluidHandlerItemStack` clears the entire tag compound when fluids are drained:
https://github.com/GregTechCEu/GregTech/blob/70bfc8aa5106c884f4243c272c95c7e77a875ed5/src/main/java/gregtech/api/capability/impl/GTFluidHandlerItemStack.java#L85-L89
This causes other NBT datas to be purged together, e.g. the `lockedFluid` for quantum tanks. (btw the locked fluid don't work for item stacks)

## Implementation Details
The `removeTagWhenEmpty` method is removed completely, since Forge handles fluid nbt clearing itself alr in `FluidHandlerItemStack#setContainerToEmpty`:
```java
/**
 * Override this method for special handling.
 * Can be used to swap out or destroy the container.
 */
protected void setContainerToEmpty() {
    container.getTagCompound().removeTag(FLUID_NBT_KEY);
}
```
This clears only the NBT tag about the fluid contained within. An extra check was added to remove the NBT when empty:
```java
@Override
protected void setContainerToEmpty() {
    super.setContainerToEmpty();
    var tag = container.getTagCompound();
    if (tag != null && tag.isEmpty()) {
        container.setTagCompound(null);
    }
}
```