### PR TITLE
Fix equals() for deposit definitions

### DIFF
--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -14,6 +14,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.Objects;
 
 public class BedrockFluidDepositDefinition implements IWorldgenDefinition {
 
@@ -160,29 +161,17 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition {
             return false;
         if (!this.storedFluid.equals(objDeposit.getStoredFluid()))
             return false;
-        if ((this.assignedName == null && objDeposit.getAssignedName() != null) ||
-                (this.assignedName != null && objDeposit.getAssignedName() == null) ||
-                (this.assignedName != null && objDeposit.getAssignedName() != null &&
-                        !this.assignedName.equals(objDeposit.getAssignedName())))
+        if (!Objects.equals(this.assignedName, objDeposit.getAssignedName()))
             return false;
-        if ((this.description == null && objDeposit.getDescription() != null) ||
-                (this.description != null && objDeposit.getDescription() == null) ||
-                (this.description != null && objDeposit.getDescription() != null &&
-                        !this.description.equals(objDeposit.getDescription())))
+        if (!Objects.equals(this.description, objDeposit.getDescription())
             return false;
         if (this.depletedYield != objDeposit.getDepletedYield())
             return false;
-        if ((this.biomeWeightModifier == null && objDeposit.getBiomeWeightModifier() != null) ||
-                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() == null) ||
-                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() != null &&
-                        !this.biomeWeightModifier.equals(objDeposit.getBiomeWeightModifier())))
+        if (!Objects.equals(this.biomeWeightModifier, objDeposit.getBiomeWeightModifier())
             return false;
-        if ((this.dimensionFilter == null && objDeposit.getDimensionFilter() != null) ||
-                (this.dimensionFilter != null && objDeposit.getDimensionFilter() == null) ||
-                (this.dimensionFilter != null && objDeposit.getDimensionFilter() != null &&
-                        !this.dimensionFilter.equals(objDeposit.getDimensionFilter())))
+        if (!Objects.equals(this.dimensionFilter, objDeposit.getDimensionFilter())
             return false;
-
+        
         return true;
     }
 }

--- a/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/BedrockFluidDepositDefinition.java
@@ -183,6 +183,6 @@ public class BedrockFluidDepositDefinition implements IWorldgenDefinition {
                         !this.dimensionFilter.equals(objDeposit.getDimensionFilter())))
             return false;
 
-        return super.equals(obj);
+        return true;
     }
 }

--- a/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
+++ b/src/main/java/gregtech/api/worldgen/config/OreDepositDefinition.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.Objects;
 
 public class OreDepositDefinition implements IWorldgenDefinition {
 
@@ -182,37 +183,19 @@ public class OreDepositDefinition implements IWorldgenDefinition {
             return false;
         if (this.getMaximumHeight() != objDeposit.getMaximumHeight())
             return false;
-        if ((this.assignedName == null && objDeposit.getAssignedName() != null) ||
-                (this.assignedName != null && objDeposit.getAssignedName() == null) ||
-                (this.assignedName != null && objDeposit.getAssignedName() != null &&
-                        !this.assignedName.equals(objDeposit.getAssignedName())))
+        if (!Objects.equals(this.assignedName, objDeposit.getAssignedName()))
             return false;
-        if ((this.description == null && objDeposit.getDescription() != null) ||
-                (this.description != null && objDeposit.getDescription() == null) ||
-                (this.description != null && objDeposit.getDescription() != null &&
-                        !this.description.equals(objDeposit.getDescription())))
+        if (!Objects.equals(this.description, objDeposit.getDescription()))
             return false;
-        if ((this.biomeWeightModifier == null && objDeposit.getBiomeWeightModifier() != null) ||
-                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() == null) ||
-                (this.biomeWeightModifier != null && objDeposit.getBiomeWeightModifier() != null &&
-                        !this.biomeWeightModifier.equals(objDeposit.getBiomeWeightModifier())))
+        if (!Objects.equals(this.biomeWeightModifier, objDeposit.getBiomeWeightModifier()))
             return false;
-        if ((this.dimensionFilter == null && objDeposit.getDimensionFilter() != null) ||
-                (this.dimensionFilter != null && objDeposit.getDimensionFilter() == null) ||
-                (this.dimensionFilter != null && objDeposit.getDimensionFilter() != null &&
-                        !this.dimensionFilter.equals(objDeposit.getDimensionFilter())))
+        if (!Objects.equals(this.dimensionFilter, objDeposit.getDimensionFilter()))
             return false;
-        if ((this.generationPredicate == null && objDeposit.getGenerationPredicate() != null) ||
-                (this.generationPredicate != null && objDeposit.getGenerationPredicate() == null) ||
-                (this.generationPredicate != null && objDeposit.getGenerationPredicate() != null &&
-                        !this.generationPredicate.equals(objDeposit.getGenerationPredicate())))
+        if (!Objects.equals(this.generationPredicate, objDeposit.getGenerationPredicate()))
             return false;
-        if ((this.veinPopulator == null && objDeposit.getVeinPopulator() != null) ||
-                (this.veinPopulator != null && objDeposit.getVeinPopulator() == null) ||
-                (this.veinPopulator != null && objDeposit.getVeinPopulator() != null &&
-                        !this.veinPopulator.equals(objDeposit.getVeinPopulator())))
+        if (!Objects.equals(this.veinPopulator, objDeposit.getVeinPopulator()))
             return false;
-
-        return super.equals(obj);
+        
+        return true;
     }
 }


### PR DESCRIPTION
## What
It looks like there's a bug in the equals() methods for `BedrockFluidDepositDefinition` and `OreDepositDefinition` where two objects constructed with the same value won't be equal.

## Implementation Details
Both methods end with a call `super.equals(other)`. That delegates to `Object.equals()` which is basically the same as `this == other`. This can't be right -- if the current behavior is correct, just delete both equals() overrides.

I also used some calls to Objects.equals() to clean up the code, but that shouldn't have any change at runtime.

I'm guessing that this doesn't matter too much in practice, but I was just poking around the code and it bugged me.

## Potential Compatibility Issues
I don't think so