### PR TITLE
Fix BQu fixer NPE

### DIFF
--- a/src/main/java/gregtech/integration/bq/BQuDataFixer.java
+++ b/src/main/java/gregtech/integration/bq/BQuDataFixer.java
@@ -225,7 +225,7 @@ public final class BQuDataFixer {
             meta = orig.get(ORIG_META_3).getAsShort();
         } else {
             itemBlockId = new ResourceLocation(id);
-            meta = jsonObject.get(DAMAGE_2).getAsShort();
+            meta = jsonObject.get(DAMAGE_2) == null ? 0 : jsonObject.get(DAMAGE_2).getAsShort();
         }
 
         ResourceLocation fixedName = migrator.fixItemName(itemBlockId, meta);


### PR DESCRIPTION
## What
Fixes an NPE that happens as soon as you try to join an already existing world with BQu quests (Credits to @WaitingIdly for the fix)

## Outcome
No more crash
