### PR TITLE
Fix multiblock UI fluid output display for parallels

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/multiblock/ui/MultiblockUIBuilder.java
+++ b/src/main/java/gregtech/api/metatileentity/multiblock/ui/MultiblockUIBuilder.java
@@ -663,7 +663,7 @@ public class MultiblockUIBuilder {
         Object2IntMap<FluidStack> fluidMap = GTHashMaps.fromFluidCollection(fluidOutputs);
 
         for (var stack : fluidMap.keySet()) {
-            addFluidOutputLine(stack, fluidMap.getInt(stack), maxProgress);
+            addFluidOutputLine(stack, (long) fluidMap.getInt(stack) * p, maxProgress);
         }
 
         for (var chancedFluidOutput : chancedFluidOutputs) {


### PR DESCRIPTION
## What
Fixes incorrect fluid output display in multiblock UI when recipes are processed with parallels.

This PR makes regular fluid output display consistent with the rest of the output display logic by scaling it with the performed parallel count as well. 

## Implementation Details

The change is limited to the multiblock UI display logic in `MultiblockUIBuilder`, simply adding the parallel factor `p`.

This mirrors the existing handling already used in the same method for item outputs and chanced outputs, where displayed amounts are multiplied by the current performed parallel count `p`.

This is a UI-only fix and does not change:

- recipe execution
- actual machine outputs
- parallel calculation
- hatch insertion logic

## Outcome
Regular fluid outputs shown in multiblock UI now scale correctly with performed parallels, matching the machine's real output behavior and aligning with how other output types are already displayed.

## Potential Compatibility Issues
None expected.
